### PR TITLE
allow all capabilities

### DIFF
--- a/docker/run-test
+++ b/docker/run-test
@@ -8,7 +8,7 @@ SCRIPTS_DIR=$(cd $(dirname $0)/../local; pwd -P)
 SOURCE_IMAGE=${1:-centos:7}
 
 docker run --rm \
-    --cap-add SYS_PTRACE \
+    --security-opt seccomp=unconfined \
     --mount type=bind,source=${ROOT_DIR},destination=/tmp/ps \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
     perconalab/ps-build:${SOURCE_IMAGE//[:\/]/-} \


### PR DESCRIPTION
SYS_PTRACE capability needed for Valgrind
SYS_NICE capability required for NUMA tests, but this capability allows `set_mempolicy` call only in latest versions of docker.
So, currently, it is simpler to disable filtering of all syscalls.

Fixes: #10