### PR TITLE
JEN-905 test-binary is LD_PRELOADing hot backup library to mtr runner…

### DIFF
--- a/local/test-binary
+++ b/local/test-binary
@@ -77,7 +77,7 @@ if [[ "$HOTBACKUP_TESTING" != "no" ]] && [[ -n "${TOKUDB_PLUGIN}" ]] && [[ -n "$
         MYSQLD_ENV="$(find /lib* /usr/lib* /usr/local/lib* -type f -name 'libasan.so*' | head -n1):${MYSQLD_ENV}"
     fi
 
-    LD_PRELOAD="${MYSQLD_ENV//:/ }" MTR_BUILD_THREAD=auto ./mtr \
+    LD_PRELOAD="${EATMYDATA} ${JEMALLOC}" MTR_BUILD_THREAD=auto ./mtr \
         --force \
         --max-test-fail=0 \
         --suite-timeout=9999 \


### PR DESCRIPTION
… when it shouldn't

[*] reduced LD_PRELOAD to ${EATMYDATA} and ${JEMALLOC} libraries