### PR TITLE
JEN-918-8.0

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -38,6 +38,7 @@ if [ -f /usr/bin/yum ]; then
 #
      PKGLIST+=" devtoolset-7-gcc-c++ devtoolset-7-binutils"
      PKGLIST+=" devtoolset-7-libasan-devel devtoolset-7-libubsan-devel"
+     PKGLIST+=" devtoolset-7-valgrind devtoolset-7-valgrind-devel"
 #
 
     until yum -y install ${PKGLIST}; do


### PR DESCRIPTION
PS AWS Jenkins: centos 6 and 7 must install Valgrind headers etc.
[+] added valgrind and valgrind-devel from devtoolset-7 for centos