### PR TITLE
JEN-923 8.0

### DIFF
--- a/local/test-binary
+++ b/local/test-binary
@@ -18,7 +18,7 @@ WORKDIR_ABS=$(cd ${1:-./build}; pwd -P)
 mkdir -p ${WORKDIR_ABS}/PS
 tar -C ${WORKDIR_ABS}/PS --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz | head -1)
 cd ${WORKDIR_ABS}/PS/mysql-test
-
+TESTCASE_TIMEOUT=60
 PARALLEL=$(grep -c ^processor /proc/cpuinfo)
 TOKUDB_PLUGIN=$(find $WORKDIR_ABS -type f -name 'ha_tokudb.so')
 HOTBACKUP_LIB=$(find $WORKDIR_ABS -type f -name 'libHotBackup.so')
@@ -30,6 +30,7 @@ if [[ "${CMAKE_BUILD_TYPE}" = "Debug" ]]; then
 fi
 if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
     MTR_ARGS+=" --valgrind --valgrind-clients --valgrind-option=--leak-check=full --valgrind-option=--show-leak-kinds=all"
+    TESTCASE_TIMEOUT=$((TESTCASE_TIMEOUT * 2))
     if [[ ${PARALLEL} -gt 1 ]]; then
         PARALLEL=$((PARALLEL/3))
     fi
@@ -64,7 +65,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         --force \
         --max-test-fail=0 \
         --suite-timeout=9999 \
-        --testcase-timeout=450 \
+        --testcase-timeout=${TESTCASE_TIMEOUT} \
         | tee ${WORKDIR_ABS}/mtr.output \
         || status=$?
     awk 'BEGIN { print "<testsuite name=\"MySQL\">" } /^([[:alnum:]]+).*[\[] (retry-)?pass [\]](.*)/ { print "<testcase name=\""$1"\" time=\"" $6/1000 "\"/>" } /^(.*) .*\[ skipped \]/ { print "<testcase name=\""$1"\"><skipped/></testcase>" } /^(.*) .*\[ (retry-)?fail \]/ { print "<testcase name=\""$1"\"><failure/></testcase>" } /^MTR\47s internal check of the test case \47(.*)\47 failed/ { print "<testcase name=\"testcase-check-"$8"\"><failure/></testcase>" } END { print "</testsuite>" }' < ${WORKDIR_ABS}/mtr.output > $WORKDIR_ABS/junit.xml
@@ -81,7 +82,7 @@ if [[ "$HOTBACKUP_TESTING" != "no" ]] && [[ -n "${TOKUDB_PLUGIN}" ]] && [[ -n "$
         --force \
         --max-test-fail=0 \
         --suite-timeout=9999 \
-        --testcase-timeout=450 \
+        --testcase-timeout=${TESTCASE_TIMEOUT} \
         --parallel=${PARALLEL} \
         ${MTR_ARGS} \
         --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
@@ -107,7 +108,7 @@ if [[ "${TOKUDB_ENGINES_MTR}" = "yes" ]] && [[ -n "${TOKUDB_PLUGIN}" ]]; then
     LD_PRELOAD="${EATMYDATA} ${JEMALLOC}" MTR_BUILD_THREAD=auto \
         ./mtr --suite=engines/iuds,engines/funcs \
             --mysqld=--default-storage-engine=tokudb --mysqld=--default-tmp-storage-engine=tokudb \
-            --suite-timeout=9999 --testcase-timeout=450 --parallel=${PARALLEL} --big-test --max-test-fail=0 \
+            --suite-timeout=9999 --testcase-timeout=${TESTCASE_TIMEOUT} --parallel=${PARALLEL} --big-test --max-test-fail=0 \
             --mysqld=--plugin-load=tokudb=ha_tokudb.so \
             --mysqld=--loose-tokudb_auto_analyze=0 --mysqld=--loose-tokudb_analyze_in_background=false \
             ${TOKUDB_ENGINES_MTR_ARGS} \


### PR DESCRIPTION
Reduce individual testcase timeout from 27000 seconds (7.5 h) to 1/2h
[*] set default testcase timeout to 60 (in minutes)
[*] increased valgrind timeout by 2 times of default testcase timeout