### PR TITLE
JEN-965

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -114,11 +114,10 @@ else
 fi
 export LSAN_OPTIONS=verbosity=2:log_threads=1:log_pointers=1
 
-# CentOS 6
-if [[ -f /opt/rh/devtoolset-2/enable ]]; then
-    source /opt/rh/devtoolset-2/enable
+# CentOS 6 and 7
+if [[ -f /opt/rh/devtoolset-7/enable ]]; then
+    source /opt/rh/devtoolset-7/enable
 fi
-
 
 # ------------------------------------------------------------------------------
 # Check tokudb

--- a/local/test-binary
+++ b/local/test-binary
@@ -29,6 +29,10 @@ if [[ "${CMAKE_BUILD_TYPE}" = "Debug" ]]; then
 fi
 if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
     MTR_ARGS+=" --valgrind --valgrind-clients --valgrind-option=--leak-check=full --valgrind-option=--show-leak-kinds=all"
+    # CentOS 6 and 7
+    if [[ -f /opt/rh/devtoolset-7/enable ]]; then
+        source /opt/rh/devtoolset-7/enable
+    fi
 elif [[ "${ANALYZER_OPTS}" == *WITH_ASAN=ON* ]]; then
     export ASAN_OPTIONS=allocator_may_return_null=true
     export LSAN_OPTIONS=verbosity=2:log_threads=1:log_pointers=1


### PR DESCRIPTION
CentOS7: percona-server-5.7-param fails with -DWITH_VALGRIND=ON
[*] use valgrind headers and binary from devtoolset for valgrind jobs