### PR TITLE
Postfix for FB8-208 (Configure Jenkins job for fb-mysql-8.0.13 branch)

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -35,7 +35,7 @@ if [ -f /usr/bin/yum ]; then
         perl-Time-HiRes libcurl-devel openldap-devel perl-Env perl-Data-Dumper \
         perl-JSON MySQL-python perl-Digest perl-Digest-MD5 perl-Digest-Perl-MD5 \
         numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan \
-        libzstd libzstd-devel \
+        libzstd-devel \
     "
 #   Percona-Server 5.6, 5.7
     if [[ ${RHVER} -eq 6 ]]; then
@@ -86,11 +86,29 @@ if [ -f /usr/bin/apt-get ]; then
         libmecab-dev libncurses5-dev libreadline-dev libpam-dev zlib1g-dev libcurl4-openssl-dev \
         libnuma-dev libjemalloc-dev libc6-dbg valgrind libjson-perl python-mysqldb \
         libmecab2 mecab mecab-ipadic git autoconf libgsasl7 libsasl2-dev libsasl2-modules devscripts \
-        debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo libzstd1 libzstd1-dev \
+        debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo \
     "
 
-    if [[ $(echo "$(lsb_release -r -s) > 18.0" | bc -l) == 1 ]] && [[ $(lsb_release -i -s) == Ubuntu ]]; then
+    DISTRIBUTOR_ID=$(lsb_release -i -s)
+    RELEASE=$(lsb_release -r -s)
+    if [[ ${DISTRIBUTOR_ID} == Ubuntu ]] && [[ $(echo "${RELEASE} >= 18.0" | bc -l) == 1 ]]; then
         PKGLIST+=" libasan5"
+    fi
+
+    # On Ubuntu install zstd only for Xenial (16.X) and higher
+    if [[ ${DISTRIBUTOR_ID} == Ubuntu ]] && [[ $(echo "${RELEASE} >= 16.0" | bc -l) == 1 ]]; then
+        if [[ $(echo "${RELEASE} >= 18.0" | bc -l) == 1 ]]; then
+            # libzstd-dev for Bionic and higher
+            PKGLIST+=" libzstd-dev"
+        else
+            # libzstd1-dev for Xenial
+            PKGLIST+=" libzstd1-dev"
+        fi
+    fi
+
+    # On Debian install zstd only for Stretch (9.X) and higher
+    if [[ ${DISTRIBUTOR_ID} == Debian ]] && [[ $(echo "${RELEASE} >= 9.0" | bc -l) == 1 ]]; then
+        PKGLIST+=" libzstd-dev"
     fi
 
     until apt-get -y install ${PKGLIST}; do

--- a/docker/prepare-docker
+++ b/docker/prepare-docker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 set -o xtrace


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-208

Fixed the way how 'zstd' library is installed in 'docker/install-deps'.

For RHEL and CentOS (yum-based distros) we now install only 'libzstd-devel'
(available in EPEL). 'libzstd' will be installed as a depencency.

For Ubuntu (apt-based):
* we install nothing for Trusty (14.X) and lower;
* we install 'libzstd1-dev' for Xenial (16.X);
* we install 'libzstd-dev' for Bionic (18.X) and higher.
'libzstd' / 'libzstd1' will be installed automatically as a depencency.

For Debian (apt-based):
* we install nothing for Jessie (8.X) and lower;
* we install 'libzstd-dev' for Stretch (9.X).
'libzstd' / 'libzstd1' will be installed automatically as a depencency.

Also, set proper shell in the 'docker/prepare-docker' script.