### PR TITLE
JEN-991 5.6 prevent merge conflict on force-pushed branches

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -135,7 +135,7 @@ pipeline {
                 sh '''
                     git reset --hard
                     git clean -xdf
-                    rm -rf sources/results
+                    sudo rm -rf sources
                     ./local/checkout
 
                     echo Build: \$(date -u "+%s")

--- a/local/checkout
+++ b/local/checkout
@@ -16,8 +16,6 @@ ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)/sources
 
 if [ ! -d "${ROOT_DIR}" ]; then
     git clone "${GIT_REPO:-https://github.com/percona/percona-server}" "${ROOT_DIR}"
-else
-    sudo chown -R $(id -u):$(id -g) "${ROOT_DIR}"
 fi
 
 pushd $ROOT_DIR


### PR DESCRIPTION
[*] remove source directory from jenkins to avoid any merge/metadata
conflicts. any local conflicts may be solved locally