### PR TITLE
JEN-991 5.7

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -152,7 +152,7 @@ pipeline {
                 sh '''
                     git reset --hard
                     git clean -xdf
-                    rm -rf sources/results
+                    sudo rm -rf sources
                     ./local/checkout
 
                     echo Build: \$(date -u "+%s")

--- a/local/checkout
+++ b/local/checkout
@@ -16,8 +16,6 @@ ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)/sources
 
 if [ ! -d "${ROOT_DIR}" ]; then
     git clone "${GIT_REPO:-https://github.com/percona/percona-server}" "${ROOT_DIR}"
-else
-    sudo chown -R $(id -u):$(id -g) "${ROOT_DIR}"
 fi
 
 pushd $ROOT_DIR


### PR DESCRIPTION
prevent merge conflict on force-pushed branches

[*] remove source directory from jenkins to avoid any merge/metadata
conflicts. any local conflicts may be solved locally