### PR TITLE
JEN-991 8.0

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -151,9 +151,7 @@ pipeline {
                     # if building failed on compilation stage directory will have files owned by docker user
                     sudo git reset --hard
                     sudo git clean -xdf
-                    rm -rf sources/results
-                    sudo git -C sources reset --hard || :
-                    sudo git -C sources clean -xdf   || :
+                    sudo rm -rf sources
                     ./local/checkout
 
                     echo Build: \$(date -u "+%s")

--- a/local/checkout
+++ b/local/checkout
@@ -16,8 +16,6 @@ ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)/sources
 
 if [ ! -d "${ROOT_DIR}" ]; then
     git clone "${GIT_REPO:-https://github.com/percona/percona-server}" "${ROOT_DIR}"
-else
-    sudo chown -R $(id -u):$(id -g) "${ROOT_DIR}"
 fi
 
 pushd $ROOT_DIR


### PR DESCRIPTION
prevent merge conflict on force-pushed branches

[*] remove source directory from jenkins to avoid any merge/metadata
conflicts. any local conflicts may be solved locally