### PR TITLE
JEN-1019-8.0

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -13,7 +13,10 @@ if (
     (params.ANALYZER_OPTS.contains('-DWITH_ASAN_SCOPE=ON')) &&
     (params.ANALYZER_OPTS.contains('-DWITH_UBSAN=ON'))) ||
     ((params.MTR_ARGS.contains('--big-test')) || (params.MTR_ARGS.contains('--only-big-test')))
-    ) { LABEL = 'docker-32gb' }
+    ) {
+        LABEL = 'docker-32gb'
+        pipeline_timeout = 13
+      }
 
 pipeline {
     parameters {


### PR DESCRIPTION
increased test timeout to 13h if running --big-test or --only-big-test

https://ps2.cd.percona.com/view/8.0/job/test-percona-server-8.0-pipeline/39/console
Timeout set to expire in 13 hr
