### PR TITLE
JEN-1066 add ubuntu 'disco' to PS jenkinses

### DIFF
--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -133,6 +133,7 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:cosmic
+          - ubuntu:disco
           - debian:stretch
           - roboxes-rhel8
     builders:

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -45,7 +45,7 @@ pipeline {
             description: 'Tag/Branch for Percona-TokuBackup repository',
             name: 'TOKUBACKUP_BRANCH')
         choice(
-            choices: 'centos:6\ncentos:7\nubuntu:xenial\nubuntu:bionic\nubuntu:cosmic\ndebian:stretch\nroboxes-rhel8',
+            choices: 'centos:6\ncentos:7\nubuntu:xenial\nubuntu:bionic\nubuntu:cosmic\nubuntu:disco\ndebian:stretch\nroboxes-rhel8',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -46,6 +46,7 @@
         - ubuntu:xenial
         - ubuntu:bionic
         - ubuntu:cosmic
+        - ubuntu:disco
         - debian:stretch
         - roboxes-rhel8
         description: OS version for compilation

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -60,6 +60,7 @@
                             "ubuntu:xenial":  { build('ubuntu:xenial') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },
                             "ubuntu:cosmic":  { build('ubuntu:cosmic') },
+                            "ubuntu:disco":   { build('ubuntu:disco') },
                             "debian:jessie":  { build('debian:jessie') },
                             "debian:stretch": { build('debian:stretch') },
                             "rhel:8":         { build('roboxes/rhel8') },

--- a/jenkins/trunk.yml
+++ b/jenkins/trunk.yml
@@ -133,6 +133,7 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:cosmic
+          - ubuntu:disco
           - debian:stretch
           - roboxes-rhel8
     builders:

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -131,6 +131,7 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:cosmic
+          - ubuntu:disco
           - debian:stretch
           - roboxes-rhel8
     builders:


### PR DESCRIPTION
https://ps3.cd.percona.com/job/percona-server-8.0-pipeline/453/
https://ps3.cd.percona.com/job/percona-server-8.0-pipeline/452/

P.S. As I can see package libssl1.0-dev is not available so libssl v 1.1.1b is used.