### PR TITLE
JEN-1084 change the value for --testcase-timeout option

### DIFF
--- a/local/test-binary
+++ b/local/test-binary
@@ -113,6 +113,11 @@ if [[ ! -e /etc/redhat-release ]]; then
     MTR_ARGS+=" --mysqld=--loose-mecab-rc-file=/etc/mecabrc"
 fi
 #
+
+if [[ $MTR_ARGS == *"--big-test"* ]] || [[ $MTR_ARGS == *"--only-big-test"* ]]; then
+    TESTCASE_TIMEOUT=$((TESTCASE_TIMEOUT * 2))
+fi
+
 status=0
 #
 # Running MTR test cases


### PR DESCRIPTION
    * in case of 'only-big-test' we need to use bigger value for
      '--testcase-timeout' option to avoid timeout issue in
      tests