### PR TITLE
JEN-960 improve mtr test output

### DIFF
--- a/local/test-binary
+++ b/local/test-binary
@@ -51,7 +51,7 @@ if [[ -z "${JEMALLOC}" ]]; then
   exit 1
 fi
 #
-MTR_ARGS+=" --timestamp --non-parallel-test"
+MTR_ARGS+=" --timestamp --non-parallel-test --report-unstable-tests"
 #
 ##
 function process_mtr_output {


### PR DESCRIPTION
    * add '--report-unstable-tests' option to show additional summary
      about unstable tests