### PR TITLE
JEN-1161 use ubuntu disco for asan tests

### DIFF
--- a/jenkins/asan-param.yml
+++ b/jenkins/asan-param.yml
@@ -162,7 +162,7 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - ubuntu:bionic
+          - ubuntu:disco
     builders:
     - trigger-builds:
       - project: percona-server-5.7-pipeline


### PR DESCRIPTION
    * for asan tests we need to use libasan5 and gcc-8+, so it is
      better to use ubuntu disco for these needs because it has
      libasan5 and gcc-8+ installed by default