### PR TITLE
ENG-898 Remove debian jessie (5.7)

### DIFF
--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -168,7 +168,6 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:jessie
           - debian:stretch
           - debian:buster
           - roboxes-rhel8

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -35,7 +35,7 @@ pipeline {
             name: 'TOKUBACKUP_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\ni386/centos:6\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:jessie\ndebian:stretch\ndebian:buster',
+            choices: 'centos:6\ncentos:7\ncentos:8\ni386/centos:6\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -48,7 +48,6 @@
         - ubuntu:xenial
         - ubuntu:bionic
         - ubuntu:focal
-        - debian:jessie
         - debian:stretch
         - debian:buster
         description: OS version for compilation

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -57,7 +57,6 @@
                             "i386/centos:6":  { build('i386/centos:6') },
                             "ubuntu:xenial":  { build('ubuntu:xenial') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },
-                            "debian:jessie":  { build('debian:jessie') },
                             "debian:stretch": { build('debian:stretch') },
                         )
                     }

--- a/jenkins/trunk.yml
+++ b/jenkins/trunk.yml
@@ -40,7 +40,6 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:jessie
           - debian:stretch
           - debian:buster
     builders:

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -167,7 +167,6 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:jessie
           - debian:stretch
           - debian:buster
     builders:


### PR DESCRIPTION
    * remove debian jessie from PS tests because end of life
      was on June 30, 2020