### PR TITLE
ENG-898 Remove debian jessie (5.6)

### DIFF
--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -141,7 +141,6 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:disco
-          - debian:jessie
           - debian:stretch
     builders:
     - trigger-builds:

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -35,7 +35,7 @@ pipeline {
             name: 'TOKUBACKUP_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ni386/centos:6\nubuntu:xenial\nubuntu:bionic\nubuntu:disco\ndebian:jessie\ndebian:stretch',
+            choices: 'centos:6\ncentos:7\ni386/centos:6\nubuntu:xenial\nubuntu:bionic\nubuntu:disco\ndebian:stretch',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -47,7 +47,6 @@
         - ubuntu:xenial
         - ubuntu:bionic
         - ubuntu:disco
-        - debian:jessie
         - debian:stretch
         description: OS version for compilation
     - choice:

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -57,7 +57,6 @@
                             "i386/centos:6":  { build('i386/centos:6') },
                             "ubuntu:xenial":  { build('ubuntu:xenial') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },
-                            "debian:jessie":  { build('debian:jessie') },
                             "debian:stretch": { build('debian:stretch') },
                         )
                     }

--- a/jenkins/trunk.yml
+++ b/jenkins/trunk.yml
@@ -39,7 +39,6 @@
           - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:disco
-          - debian:jessie
           - debian:stretch
     builders:
     - trigger-builds:


### PR DESCRIPTION
    * remove debian jessie from PS tests because end of life
      was on June 30, 2020