### PR TITLE
PS-7390: Remove --non-parallel-test from default MTR args

### DIFF
--- a/local/test-binary
+++ b/local/test-binary
@@ -56,7 +56,7 @@ if [[ -z "${JEMALLOC}" ]]; then
   exit 1
 fi
 #
-MTR_ARGS+=" --timestamp --non-parallel-test --report-unstable-tests"
+MTR_ARGS+=" --timestamp --report-unstable-tests"
 #
 ##
 function process_mtr_output {


### PR DESCRIPTION
If we want to have a backward compatibility(in order to run older than 8.0.22) I'd add a version check from `mysqld --version`

https://ps3.cd.percona.com/job/percona-server-8.0-pipeline/3625/ build