### PR TITLE
FB8-252: Add python3 for CentOS 8

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -61,7 +61,7 @@ if [ -f /usr/bin/yum ]; then
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
-        PKGLIST+=" lz4 perl-Memoize perl-open valgrind-devel libubsan rpcgen libtirpc-devel golang libunwind-devel"
+        PKGLIST+=" lz4 perl-Memoize perl-open valgrind-devel libubsan rpcgen libtirpc-devel golang libunwind-devel python2 python3"
     fi
 
     if [[ ${RHVER} -eq 7 ]]; then
@@ -98,7 +98,7 @@ if [ -f /usr/bin/yum ]; then
     done
 
     if [[ ${RHVER} -eq 8 ]]; then
-        ln -fs /usr/bin/python2 /usr/bin/python
+        ln -fs /usr/bin/python3 /usr/bin/python
     fi
 
 #   this is workaround for https://bugs.mysql.com/bug.php?id=95222 as soon as the issue is fixed we need to remove it 


### PR DESCRIPTION
Builds: https://ps3.cd.percona.com/view/8.0-fb/job/fb-mysql-server-8.0-pipeline/81

Note: Err: `ModuleNotFoundError: No module named 'MySQLdb'` is for another ticket (FB8-254)