### PR TITLE
FB8-257: Correct python link for buster & bionic

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -190,7 +190,7 @@ if [ -f /usr/bin/apt-get ]; then
 
     apt-get -y clean
 
-    if [[ ${DIST} == 'focal' ]]; then
+    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'buster' ]] || [[ ${DIST} == 'bionic' ]]; then
         ln -fs /usr/bin/python3 /usr/bin/python
     fi
 fi


### PR DESCRIPTION
Upon investigation, I found only two images were missing the python symlink

Test builds:
* https://ps3.cd.percona.com/view/5.7/job/percona-server-5.7-pipeline/1673/
* https://ps3.cd.percona.com/view/5.7/job/percona-server-5.7-pipeline/1675/