### PR TITLE
FB8-254: Install MySQLdb python module

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -57,7 +57,7 @@ if [ -f /usr/bin/yum ]; then
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
     perl-JSON MySQL-python perl-Digest perl-Digest-MD5 \
     numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan lz4-devel \
-    libzstd-devel tzdata zstd \
+    libzstd-devel tzdata zstd mysql-devel python3-pip python3-devel \
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -101,6 +101,9 @@ if [ -f /usr/bin/yum ]; then
         ln -fs /usr/bin/python3 /usr/bin/python
     fi
 
+    # Install mysqlclient by pip as there's no candidate in repositories
+    pip3 install mysqlclient
+
 #   this is workaround for https://bugs.mysql.com/bug.php?id=95222 as soon as the issue is fixed we need to remove it 
     if [ -f '/anaconda-post.log' ]; then
         rm /anaconda-post.log
@@ -138,13 +141,8 @@ if [ -f /usr/bin/apt-get ]; then
         libnuma-dev libjemalloc-dev libc6-dbg valgrind libjson-perl libevent-dev pkg-config \
         libmecab2 mecab mecab-ipadic git autoconf libgsasl7 libsasl2-dev libsasl2-modules devscripts \
         debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
-        tzdata golang libunwind-dev zstd \
+        tzdata golang libunwind-dev zstd python3-mysqldb \
     "
-    if [[ ${DIST} != 'focal' ]]; then
-        PKGLIST+=" python-mysqldb"
-    else
-        PKGLIST+=" python3-mysqldb"
-    fi
 
     DISTRIBUTOR_ID=$(lsb_release -i -s)
     RELEASE=$(lsb_release -r -s)


### PR DESCRIPTION
builds for failed OS:
https://ps3.cd.percona.com/job/percona-server-5.7-pipeline/1678/
https://ps3.cd.percona.com/job/percona-server-5.7-pipeline/1679/

Issue:
```
CURRENT_TEST: innodb_stress.innodb_stress
Traceback (most recent call last):
  File "/tmp/results/PS//mysql-test/suite/innodb_stress/t/load_generator.py", line 4, in <module>
    import MySQLdb
ImportError: No module named MySQLdb
mysqltest: In included file ./suite/innodb_stress/include/innodb_stress.inc at line 85:
included from /tmp/results/PS/mysql-test/suite/innodb_stress/t/innodb_stress.test at line 37:
At line 85: command "$exec" failed
```

https://ps57.cd.percona.com/job/percona-server-5.7-param/361/CMAKE_BUILD_TYPE=Debug,DOCKER_OS=debian%3Astretch/#showFailuresLink
https://ps57.cd.percona.com/job/percona-server-5.7-param/361/CMAKE_BUILD_TYPE=Debug,DOCKER_OS=ubuntu%3Axenial/#showFailuresLink