### PR TITLE
FB8-257: Use python3 for all ubuntu/debian distros

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -190,9 +190,10 @@ if [ -f /usr/bin/apt-get ]; then
 
     apt-get -y clean
 
-    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'buster' ]] || [[ ${DIST} == 'bionic' ]]; then
-        ln -fs /usr/bin/python3 /usr/bin/python
+    if [[ -L /usr/bin/python ]]; then
+        rm /usr/bin/python
     fi
+    ln -fs /usr/bin/python3 /usr/bin/python
 fi
 
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then


### PR DESCRIPTION
builds for failed OS:
https://ps3.cd.percona.com/job/percona-server-5.7-pipeline/1678/
https://ps3.cd.percona.com/job/percona-server-5.7-pipeline/1679/

Issue:
```
CURRENT_TEST: innodb_stress.innodb_stress
Traceback (most recent call last):
  File "/tmp/results/PS//mysql-test/suite/innodb_stress/t/load_generator.py", line 4, in <module>
    import MySQLdb
ImportError: No module named MySQLdb
mysqltest: In included file ./suite/innodb_stress/include/innodb_stress.inc at line 85:
included from /tmp/results/PS/mysql-test/suite/innodb_stress/t/innodb_stress.test at line 37:
At line 85: command "$exec" failed
```

https://ps57.cd.percona.com/job/percona-server-5.7-param/361/CMAKE_BUILD_TYPE=Debug,DOCKER_OS=debian%3Astretch/#showFailuresLink
https://ps57.cd.percona.com/job/percona-server-5.7-param/361/CMAKE_BUILD_TYPE=Debug,DOCKER_OS=ubuntu%3Axenial/#showFailuresLink