### PR TITLE
PS-7382: Add dependencies for Hashicorp Vault MTR tests

### DIFF
--- a/docker/Dockerfile.inc
+++ b/docker/Dockerfile.inc
@@ -1,6 +1,7 @@
 FROM centos:7
 
 COPY install-deps /tmp/install-deps
+COPY vault_supervisord.ini /tmp/vault_supervisord.ini
 RUN /tmp/install-deps
 
 RUN echo "mysql ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/docker/install-deps
+++ b/docker/install-deps
@@ -224,11 +224,14 @@ wget_loop 'boost_1_67_0.tar.gz' 'http://downloads.sourceforge.net/boost/boost/1.
 wget_loop 'googletest-release-1.8.0.zip' 'https://github.com/google/googletest/archive/release-1.8.0.zip'
 
 # Download Hashicorp Vault
-wget_loop "vault_0.9.6.zip" "https://releases.hashicorp.com/vault/0.9.6/vault_0.9.6_linux_amd64.zip"
-wget_loop "vault_1.5.4.zip" "https://releases.hashicorp.com/vault/1.5.4/vault_1.5.4_linux_amd64.zip"
+LATEST_V1_VERSION=0.9.6
+LATEST_V2_VERSION=1.5.4
+
+wget_loop "vault_v1.zip" "https://releases.hashicorp.com/vault/$LATEST_V1_VERSION/vault_${LATEST_V1_VERSION}_linux_amd64.zip"
+wget_loop "vault_v2.zip" "https://releases.hashicorp.com/vault/$LATEST_V2_VERSION/vault_${LATEST_V2_VERSION}_linux_amd64.zip"
 
 # Vault setup
-for VER in 0.9.6 1.5.4; do
+for VER in v1 v2; do
     unzip /tmp/source_downloads/vault_$VER.zip && install vault /usr/local/bin/vault.$VER && rm vault /tmp/source_downloads/vault_$VER.zip 
     if [[ -f /usr/bin/yum ]]; then
         setcap cap_ipc_lock= /usr/local/bin/vault.$VER
@@ -245,7 +248,7 @@ for VER in 0.9.6 1.5.4; do
     chown vault-$VER-prod:vault-$VER-prod /etc/vault.d-$VER-prod/policy
 done
 
-cat <<-EOF | tee /etc/vault.d-0.9.6-prod/config.hcl
+cat <<-EOF | tee /etc/vault.d-v1-prod/config.hcl
 disable_cache = true
 disable_mlock = true
 
@@ -264,7 +267,7 @@ api_addr = "http://127.0.0.1:9300"
 cluster_addr = "https://127.0.0.1:9301"
 EOF
 
-cat <<-EOF | tee /etc/vault.d-1.5.4-prod/config.hcl
+cat <<-EOF | tee /etc/vault.d-v2-prod/config.hcl
 disable_cache = true
 disable_mlock = true
 

--- a/docker/install-deps
+++ b/docker/install-deps
@@ -57,7 +57,7 @@ if [ -f /usr/bin/yum ]; then
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
     perl-JSON MySQL-python perl-Digest perl-Digest-MD5 \
     numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan lz4-devel \
-    libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql \
+    libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq supervisor \
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -114,6 +114,7 @@ if [ -f /usr/bin/yum ]; then
     if [ -f '/anaconda-post.log' ]; then
         rm /anaconda-post.log
     fi
+    mv /tmp/vault_supervisord.ini /etc/supervisord.d/vault.ini
 fi
 
 if [ -f /usr/bin/apt-get ]; then
@@ -148,6 +149,7 @@ if [ -f /usr/bin/apt-get ]; then
         libmecab2 mecab mecab-ipadic git autoconf libgsasl7 libsasl2-dev libsasl2-modules devscripts \
         debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
         tzdata golang libunwind-dev zstd python3-mysqldb libdbi-perl libdbd-mysql-perl \
+        jq supervisor libcap2-bin \
     "
 
     DISTRIBUTOR_ID=$(lsb_release -i -s)
@@ -194,6 +196,7 @@ if [ -f /usr/bin/apt-get ]; then
         rm /usr/bin/python
     fi
     ln -fs /usr/bin/python3 /usr/bin/python
+    mv /tmp/vault_supervisord.ini /etc/supervisor/conf.d/vault.conf
 fi
 
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then
@@ -219,3 +222,89 @@ wget_loop 'boost_1_67_0.tar.gz' 'http://downloads.sourceforge.net/boost/boost/1.
 
 # googletest 1.8.0 needed for percona-server versions 5.6 to 8.0
 wget_loop 'googletest-release-1.8.0.zip' 'https://github.com/google/googletest/archive/release-1.8.0.zip'
+
+# Download Hashicorp Vault
+wget_loop "vault_0.9.6.zip" "https://releases.hashicorp.com/vault/0.9.6/vault_0.9.6_linux_amd64.zip"
+wget_loop "vault_1.5.4.zip" "https://releases.hashicorp.com/vault/1.5.4/vault_1.5.4_linux_amd64.zip"
+
+# Vault setup
+for VER in 0.9.6 1.5.4; do
+    unzip /tmp/source_downloads/vault_$VER.zip && install vault /usr/local/bin/vault.$VER && rm vault /tmp/source_downloads/vault_$VER.zip 
+    if [[ -f /usr/bin/yum ]]; then
+        setcap cap_ipc_lock= /usr/local/bin/vault.$VER
+    else
+        /sbin/setcap cap_ipc_lock= /usr/local/bin/vault.$VER
+    fi
+
+    useradd -m --system --home /etc/vault.d-$VER-dev --shell /bin/false vault-$VER-dev
+    useradd -m --system --home /etc/vault.d-$VER-prod --shell /bin/false vault-$VER-prod
+
+    mkdir /etc/vault.d-$VER-dev/policy
+    mkdir /etc/vault.d-$VER-prod/policy
+    chown vault-$VER-dev:vault-$VER-dev /etc/vault.d-$VER-dev/policy
+    chown vault-$VER-prod:vault-$VER-prod /etc/vault.d-$VER-prod/policy
+done
+
+cat <<-EOF | tee /etc/vault.d-0.9.6-prod/config.hcl
+disable_cache = true
+disable_mlock = true
+
+listener "tcp" {
+  address          = "127.0.0.1:9300"
+  cluster_address  = "127.0.0.1:9301"
+  tls_disable      = "true"
+}
+
+storage "consul" {
+  address = "127.0.0.1:8500"
+  path    = "vault-0-prod/"
+}
+
+api_addr = "http://127.0.0.1:9300"
+cluster_addr = "https://127.0.0.1:9301"
+EOF
+
+cat <<-EOF | tee /etc/vault.d-1.5.4-prod/config.hcl
+disable_cache = true
+disable_mlock = true
+
+listener "tcp" {
+  address          = "127.0.0.1:9500"
+  cluster_address  = "127.0.0.1:9501"
+  tls_disable      = "true"
+}
+
+storage "consul" {
+  address = "127.0.0.1:8500"
+  path    = "vault-1-prod/"
+}
+
+api_addr = "http://127.0.0.1:9500"
+cluster_addr = "https://127.0.0.1:9501"
+EOF
+
+# Consul setup
+# Consul is stronly adviced to use as a backend for Vault in production mode
+wget_loop 'consul_1.8.5.zip' 'https://releases.hashicorp.com/consul/1.8.5/consul_1.8.5_linux_amd64.zip'
+unzip /tmp/source_downloads/consul_1.8.5.zip && install consul /usr/local/bin/consul && rm consul /tmp/source_downloads/consul_1.8.5.zip
+useradd -m --system --home /etc/consul.d --shell /bin/false consul
+mkdir -p /var/consul/data && chown -R consul:consul /var/consul/
+
+cat <<-EOF | tee /etc/consul.d/config.json
+{
+  "server": true,
+  "node_name": "main",
+  "datacenter": "perconatest",
+  "data_dir": "/var/consul/data",
+  "bind_addr": "127.0.0.1",
+  "client_addr": "127.0.0.1",
+  "advertise_addr": "127.0.0.1",
+  "bootstrap_expect": 1,
+  "retry_join": ["127.0.0.1"],
+  "ui": false,
+  "log_level": "INFO",
+  "enable_syslog": false,
+  "acl_enforce_version_8": false
+}
+EOF
+

--- a/docker/vault_supervisord.ini
+++ b/docker/vault_supervisord.ini
@@ -6,36 +6,36 @@ command=/usr/local/bin/consul agent -config-file=/etc/consul.d/config.json -pid-
 stderr_logfile = /tmp/results/consul.err.log
 stdout_logfile = /tmp/results/consul.log
 
-[program:vault-0.9.6-dev]
+[program:vault-v1-dev]
 priority=2
-user=vault-0.9.6-dev
-directory=/etc/vault.d-0.9.6-dev/
-environment=HOME="/etc/vault.d-0.9.6-dev/",USER="vault-0.9.6-dev"
-command=/usr/local/bin/vault.0.9.6 server -dev -dev-listen-address=127.0.0.1:9200 -dev-root-token-id=devtoken1
-stderr_logfile = /tmp/results/vault.0.9.6-dev.err.log
-stdout_logfile = /tmp/results/vault.0.9.6-dev.log
+user=vault-v1-dev
+directory=/etc/vault.d-v1-dev/
+environment=HOME="/etc/vault.d-v1-dev/",USER="vault-v1-dev"
+command=/usr/local/bin/vault.v1 server -dev -dev-listen-address=127.0.0.1:9200 -dev-root-token-id=devtoken1
+stderr_logfile = /tmp/results/vault.v1-dev.err.log
+stdout_logfile = /tmp/results/vault.v1-dev.log
 
-[program:vault-1.5.4-dev]
+[program:vault-v2-dev]
 priority=2
-user=vault-1.5.4-dev
-directory=/etc/vault.d-1.5.4-dev/
-environment=HOME="/etc/vault.d-1.5.4-dev/",USER="vault-1.5.4-dev"
-command=/usr/local/bin/vault.1.5.4 server -dev -dev-listen-address=127.0.0.1:9400 -dev-root-token-id=devtoken2
-stderr_logfile = /tmp/results/vault.1.5.4-dev.err.log
-stdout_logfile = /tmp/results/vault.1.5.4-dev.log
+user=vault-v2-dev
+directory=/etc/vault.d-v2-dev/
+environment=HOME="/etc/vault.d-v2-dev/",USER="vault-v2-dev"
+command=/usr/local/bin/vault.v2 server -dev -dev-listen-address=127.0.0.1:9400 -dev-root-token-id=devtoken2
+stderr_logfile = /tmp/results/vault.v2-dev.err.log
+stdout_logfile = /tmp/results/vault.v2-dev.log
 
-[program:vault-0.9.6-prod]
+[program:vault-v1-prod]
 priority=3
-user=vault-0.9.6-prod
-environment=HOME="/etc/vault.d-0.9.6-prod/",USER="vault-0.9.6-prod"
-command=/usr/local/bin/vault.0.9.6 server -config=/etc/vault.d-0.9.6-prod/config.hcl
-stderr_logfile = /tmp/results/vault.0.9.6-prod.err.log
-stdout_logfile = /tmp/results/vault.0.9.6-prod.log
+user=vault-v1-prod
+environment=HOME="/etc/vault.d-v1-prod/",USER="vault-v1-prod"
+command=/usr/local/bin/vault.v1 server -config=/etc/vault.d-v1-prod/config.hcl
+stderr_logfile = /tmp/results/vault.v1-prod.err.log
+stdout_logfile = /tmp/results/vault.v1-prod.log
 
-[program:vault_1.5.4-prod]
+[program:vault_v2-prod]
 priority=3
-user=vault-1.5.4-prod
-environment=HOME="/etc/vault.d-1.5.4-prod/",USER="vault-1.5.4-prod"
-command=/usr/local/bin/vault.1.5.4 server -config=/etc/vault.d-1.5.4-prod/config.hcl
-stderr_logfile = /tmp/results/vault.1.5.4-prod.err.log
-stdout_logfile = /tmp/results/vault.1.5.4-prod.log
+user=vault-v2-prod
+environment=HOME="/etc/vault.d-v2-prod/",USER="vault-v2-prod"
+command=/usr/local/bin/vault.v2 server -config=/etc/vault.d-v2-prod/config.hcl
+stderr_logfile = /tmp/results/vault.v2-prod.err.log
+stdout_logfile = /tmp/results/vault.v2-prod.log

--- a/docker/vault_supervisord.ini
+++ b/docker/vault_supervisord.ini
@@ -1,0 +1,41 @@
+[program:consul]
+priority=1
+user=consul
+environment=HOME="/etc/consul.d/",USER="consul"
+command=/usr/local/bin/consul agent -config-file=/etc/consul.d/config.json -pid-file=/etc/consul.d/consul.pid
+stderr_logfile = /tmp/results/consul.err.log
+stdout_logfile = /tmp/results/consul.log
+
+[program:vault-0.9.6-dev]
+priority=2
+user=vault-0.9.6-dev
+directory=/etc/vault.d-0.9.6-dev/
+environment=HOME="/etc/vault.d-0.9.6-dev/",USER="vault-0.9.6-dev"
+command=/usr/local/bin/vault.0.9.6 server -dev -dev-listen-address=127.0.0.1:9200 -dev-root-token-id=devtoken1
+stderr_logfile = /tmp/results/vault.0.9.6-dev.err.log
+stdout_logfile = /tmp/results/vault.0.9.6-dev.log
+
+[program:vault-1.5.4-dev]
+priority=2
+user=vault-1.5.4-dev
+directory=/etc/vault.d-1.5.4-dev/
+environment=HOME="/etc/vault.d-1.5.4-dev/",USER="vault-1.5.4-dev"
+command=/usr/local/bin/vault.1.5.4 server -dev -dev-listen-address=127.0.0.1:9400 -dev-root-token-id=devtoken2
+stderr_logfile = /tmp/results/vault.1.5.4-dev.err.log
+stdout_logfile = /tmp/results/vault.1.5.4-dev.log
+
+[program:vault-0.9.6-prod]
+priority=3
+user=vault-0.9.6-prod
+environment=HOME="/etc/vault.d-0.9.6-prod/",USER="vault-0.9.6-prod"
+command=/usr/local/bin/vault.0.9.6 server -config=/etc/vault.d-0.9.6-prod/config.hcl
+stderr_logfile = /tmp/results/vault.0.9.6-prod.err.log
+stdout_logfile = /tmp/results/vault.0.9.6-prod.log
+
+[program:vault_1.5.4-prod]
+priority=3
+user=vault-1.5.4-prod
+environment=HOME="/etc/vault.d-1.5.4-prod/",USER="vault-1.5.4-prod"
+command=/usr/local/bin/vault.1.5.4 server -config=/etc/vault.d-1.5.4-prod/config.hcl
+stderr_logfile = /tmp/results/vault.1.5.4-prod.err.log
+stdout_logfile = /tmp/results/vault.1.5.4-prod.log


### PR DESCRIPTION
First part of implementation, Yura started working on 5.7, but `ps-build` image for 5.7 uses the one from 8.0 branch

Next PR will be for 5.7: MTR tests and all required changes to run build with Vault

Latest build with changes which used the `ps-build` with these changes: https://ps57.cd.percona.com/job/percona-server-5.7-pipeline-ps-7382/11/