### PR TITLE
FB8-255: Add Perl-DBI and Perl-DBD dependency for rqg tests

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -57,7 +57,7 @@ if [ -f /usr/bin/yum ]; then
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
     perl-JSON MySQL-python perl-Digest perl-Digest-MD5 \
     numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan lz4-devel \
-    libzstd-devel tzdata zstd mysql-devel \
+    libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql \
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -147,7 +147,7 @@ if [ -f /usr/bin/apt-get ]; then
         libnuma-dev libjemalloc-dev libc6-dbg valgrind libjson-perl libevent-dev pkg-config \
         libmecab2 mecab mecab-ipadic git autoconf libgsasl7 libsasl2-dev libsasl2-modules devscripts \
         debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
-        tzdata golang libunwind-dev zstd python3-mysqldb \
+        tzdata golang libunwind-dev zstd python3-mysqldb libdbi-perl libdbd-mysql-perl \
     "
 
     DISTRIBUTOR_ID=$(lsb_release -i -s)


### PR DESCRIPTION
Builds: 
* https://ps3.cd.percona.com/view/8.0-fb/job/fb-mysql-server-8.0-pipeline/111/
* https://ps3.cd.percona.com/view/8.0-fb/job/fb-mysql-server-8.0-pipeline/110/

Before: https://fb.cd.percona.com/job/fb-mysql-server-8.0-param/217/#showFailuresLink
```
+Can't locate DBI.pm in @INC (you may need to install the DBI module) (@INC contains: /tmp/results/PS/mysql-test/../rqg/rqg/common/mariadb-patches/lib lib /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /tmp/results/PS/mysql-test/../rqg/rqg/common/mariadb-patches/lib/GenTest/App/Gendata.pm line 23.
```
