### PR TITLE
PS-7515: Use Percona CentOS 6 mirror for CentOS 6 image

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -19,13 +19,26 @@ if [ -f /usr/bin/yum ]; then
   RHVER="$(rpm --eval %rhel)"
   rpm --eval %_arch > /etc/yum/vars/basearch
 
+  if [[ ${RHVER} -eq 6 ]]; then
+    curl https://jenkins.percona.com/downloads/cent6/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+  fi
+
   until yum -y update; do
     yum clean all
     echo "waiting"
     sleep 1
   done
 
-  PKGLIST+=" wget epel-release"
+  PKGLIST+=" wget"
+
+  until yum -y install epel-release; do
+    echo "waiting"
+    sleep 1
+  done
+  if [[ ${RHVER} -eq 6 ]]; then
+    rm /etc/yum.repos.d/epel-testing.repo
+    curl https://jenkins.percona.com/downloads/cent6/centos6-epel-eol.repo --output /etc/yum.repos.d/epel.repo
+  fi
 
   if [[ ${RHVER} -eq 8 ]]; then
       PKGLIST+=" dnf-utils"
@@ -39,7 +52,14 @@ if [ -f /usr/bin/yum ]; then
   fi
 
   if [[ ${RHVER} -lt 8 ]]; then
-      PKGLIST+=" centos-release-scl"
+    until yum -y install centos-release-scl; do
+      echo "waiting"
+      sleep 1
+    done
+    if [[ ${RHVER} -eq 6 ]]; then
+      curl https://jenkins.percona.com/downloads/cent6/centos6-scl-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl.repo
+      curl https://jenkins.percona.com/downloads/cent6/centos6-scl-rh-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+    fi
   fi
   until yum -y install ${PKGLIST}; do
     echo "waiting"

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -52,6 +52,7 @@
                 stage('Build') {
                     steps {
                         parallel(
+                            "centos:6":  { build('centos:6') },
                             "centos:7":  { build('centos:7') },
                             "centos:8":  { build('centos:8') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },


### PR DESCRIPTION
This change is needed to have a support for PS80/57/56 pipelines on CentOS 6 image