### PR TITLE
PS-7543: Install devtoolset-8's libatomic

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -113,7 +113,7 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST+=" devtoolset-7-valgrind devtoolset-7-valgrind-devel devtoolset-7-libatomic-devel"
         PKGLIST+=" devtoolset-8-gcc-c++ devtoolset-8-binutils"
         PKGLIST+=" devtoolset-8-libasan-devel devtoolset-8-libubsan-devel"
-        PKGLIST+=" devtoolset-8-valgrind devtoolset-8-valgrind-devel perl-Digest-Perl-MD5 libedit-devel"
+        PKGLIST+=" devtoolset-8-valgrind devtoolset-8-valgrind-devel devtoolset-8-libatomic-devel perl-Digest-Perl-MD5 libedit-devel"
     fi
 
     until yum -y install ${PKGLIST} ; do


### PR DESCRIPTION
This needed for proper compilation with devtoolset on FB pipelines on CentOS 6/7 as it uses devtoolset-8

Builds: https://fb.cd.percona.com/job/fb-mysql-server-8.0-pipeline-ps-7543/1/ please ignore failed tests, they are disabled
Failed build: https://fb.cd.percona.com/job/fb-mysql-server-8.0-pipeline/1061/consoleFull