### PR TITLE
PS-7560: Add python-argparse for RocksDB tests on CentOS 6

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -99,7 +99,7 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST+=" devtoolset-2-gcc-c++ devtoolset-2-binutils"
         PKGLIST+=" devtoolset-2-libasan-devel"
         PKGLIST+=" devtoolset-2-valgrind devtoolset-2-valgrind-devel"
-        PKGLIST+=" libevent2-devel"
+        PKGLIST+=" libevent2-devel python-argparse"
     fi
 
     if [[ ${RHVER} -gt 6 ]]; then


### PR DESCRIPTION
Builds: https://ps57.cd.percona.com/job/percona-server-5.7-pipeline-ps-7560/1/testReport/

Failed test mentioned in Jira ticket:
```
CURRENT_TEST: rocksdb_stress.drop_cf_stress Traceback (most recent call last): File "/tmp/results/PS//mysql-test/suite/rocksdb_stress/t/drop_cf_stress.py", line 13, in <module> import argparse ImportError: No module named argparse mysqltest: At line 73: command "$exec" failed
```