### PR TITLE
FB8-259: Increase pipeline_timeout for Debug builds

### DIFF
--- a/jenkins/pipeline-fb.groovy
+++ b/jenkins/pipeline-fb.groovy
@@ -1,4 +1,4 @@
-pipeline_timeout = 13
+pipeline_timeout = 24
 
 if (
     (params.ANALYZER_OPTS.contains('-DWITH_ASAN=ON')) ||


### PR DESCRIPTION
Builds: https://fb.cd.percona.com/job/fb-mysql-server-8.0-param-fb8-259-debug/1/
Failed builds: https://fb.cd.percona.com/job/fb-mysql-server-8.0-param/246/