### PR TITLE
PS-7629: Install libcurl-devel for all RHEL versions

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -77,7 +77,7 @@ if [ -f /usr/bin/yum ]; then
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
     perl-JSON MySQL-python perl-Digest perl-Digest-MD5 \
     numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan lz4-devel \
-    libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq openssl perl-XML-Simple \
+    libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq openssl perl-XML-Simple libcurl-devel \
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -103,7 +103,7 @@ if [ -f /usr/bin/yum ]; then
     fi
 
     if [[ ${RHVER} -gt 6 ]]; then
-        PKGLIST+=" libevent-devel libcurl-devel"
+        PKGLIST+=" libevent-devel"
     fi
 
 #   Percona-Server 8.0


### PR DESCRIPTION
Failed URL: https://ps80.cd.percona.com/job/percona-server-8.0-pipeline/27910/

Fixed builds:
RelWithDebInfo: https://ps80.cd.percona.com/job/percona-server-8.0-pipeline-ps-7629/3/
Debug: https://ps80.cd.percona.com/job/percona-server-8.0-pipeline-ps-7629/4/