### PR TITLE
PS-7639: Build libeatmydata 128 version for now

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -223,6 +223,7 @@ fi
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then
     git clone https://github.com/stewartsmith/libeatmydata /tmp/libeatmydata
     pushd /tmp/libeatmydata
+        # PS-7639: Needed for CentOS 6 because of ancient autoconf
         if [ -f /usr/bin/yum ]; then
             RHVER="$(rpm --eval %rhel)"
             if [[ ${RHVER} -eq 6 ]]; then

--- a/docker/install-deps
+++ b/docker/install-deps
@@ -223,7 +223,12 @@ fi
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then
     git clone https://github.com/stewartsmith/libeatmydata /tmp/libeatmydata
     pushd /tmp/libeatmydata
-        git checkout df7ddeb0345104f25b5b7bb154bc6a008c8c8404
+        if [ -f /usr/bin/yum ]; then
+            RHVER="$(rpm --eval %rhel)"
+            if [[ ${RHVER} -eq 6 ]]; then
+                git checkout df7ddeb0345104f25b5b7bb154bc6a008c8c8404
+            fi
+        fi
         autoreconf --force --install
         ./configure
         make

--- a/docker/install-deps
+++ b/docker/install-deps
@@ -223,6 +223,7 @@ fi
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then
     git clone https://github.com/stewartsmith/libeatmydata /tmp/libeatmydata
     pushd /tmp/libeatmydata
+        git checkout df7ddeb0345104f25b5b7bb154bc6a008c8c8404
         autoreconf --force --install
         ./configure
         make


### PR DESCRIPTION
129 version, which was pushed 4 days ago fails to build on CentOS 6 due to old autoconf
