### PR TITLE
PS-7650: Add missing dependency for trunk-fips run and update code

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -32,7 +32,7 @@ if [ -f /usr/bin/yum ]; then
         time zlib-devel libaio-devel bison cmake pam-devel jemalloc-devel valgrind \
         perl-Time-HiRes libcurl-devel openldap-devel perl-Env perl-Data-Dumper \
         perl-JSON MySQL-python perl-Digest perl-Digest-MD5 perl-Digest-Perl-MD5 \
-        numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan \
+        numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan perl-XML-Simple \
     "
     if [[ "$(rpm --eval %rhel)" = "6" ]]; then
         cat <<-EOF | tee /etc/yum.repos.d/devtoolset-2.repo


### PR DESCRIPTION
Builds: https://ps57.cd.percona.com/job/percona-server-5.7-trunk-fips/470/

Merge after deployment of: https://github.com/Percona-Lab/jenkins-pipelines/pull/917