### PR TITLE
PS-7693: Increase timeout for builds with --big-test

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -15,7 +15,7 @@ if (
     ((params.MTR_ARGS.contains('--big-test')) || (params.MTR_ARGS.contains('--only-big-test')))
     ) {
         LABEL = 'docker-32gb'
-        pipeline_timeout = 13
+        pipeline_timeout = 20
       }
 
 pipeline {


### PR DESCRIPTION
Builds: https://ps80.cd.percona.com/job/percona-server-8.0-param-PS-7693/2/

It's needed when WITH_ROCKSDB & WITH_TOKUDB enabled and --big-test passed to MTR_ARGS for Debug builds