### PR TITLE
PS-7718: [8.0] Correct conditional check for cleaning up docker images on docker workers

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -277,8 +277,8 @@ pipeline {
                                     echo Test: \$(date -u "+%s")
                                     aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
                                     sg docker -c "
-                                        if [ \$(docker ps -q | wc -l) -ne 0 ]; then
-                                            docker ps -q | xargs docker stop --time 1 || :
+                                        if [ \$(docker ps -a -q | wc -l) -ne 0 ]; then
+                                            docker ps -a -q | xargs docker stop --time 1 || :
                                             docker rm --force consul vault-prod-v{1..2} vault-dev-v{1..2} || :
                                         fi
                                         ulimit -a


### PR DESCRIPTION
This change is needed, when vault|consul|ps-build image was spawned, but stuck in "Created" state
`docker ps -q` will return 0, even if there's a container

This can happen on dirty worker, where PS pipeline was aborted, on bootstrap of vault
Next run will fail, due to existing containers with same name

Before:
```
sudokamikaze at Sudokamikazes-Work-MacBook-Pro in /tmp
$ docker ps -q | wc -l
       0

sudokamikaze at Sudokamikazes-Work-MacBook-Pro in /tmp
$ docker ps -a
CONTAINER ID   IMAGE         COMMAND                  CREATED         STATUS    PORTS     NAMES
49ad8ff4ce7f   vault:0.9.6   "docker-entrypoint.s…"   2 minutes ago   Created             vault-dev-v1
```

After:
```
$ docker ps -a -q | wc -l
       1
```

No builds are needed(from my point of view) as it can be reproduced locally
