### PR TITLE
PS-7823: Update conditional check to ensure that GMOCK_PACKAGE_NAME variable exist before downloading actual googletest

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -55,13 +55,15 @@ wget_loop() {
 BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
 wget_loop "boost_${BOOST_VERSION}.tar.gz" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
 
-if [ -f "${SOURCEDIR}/cmake/googletest.cmake" ]; then
-    GMOCK_VERSION=$(grep 'SET(GMOCK_PACKAGE_NAME' ${SOURCEDIR}/cmake/googletest.cmake | sed -re 's/.*([0-9]+[.][0-9]+[.][0-9]+).*/\1/')
-else
-    GMOCK_VERSION=$(grep 'SET(GMOCK_PACKAGE_NAME' ${SOURCEDIR}/unittest/gunit/CMakeLists.txt | sed -re 's/.*([0-9]+[.][0-9]+[.][0-9]+).*/\1/')
-fi
+if grep -q GMOCK_PACKAGE_NAME ${SOURCEDIR}/cmake/googletest.cmake || grep -q GMOCK_PACKAGE_NAME ${SOURCEDIR}/unittest/gunit/CMakeLists.txt; then
+    if [ -f "${SOURCEDIR}/cmake/googletest.cmake" ]; then
+        GMOCK_VERSION=$(grep 'SET(GMOCK_PACKAGE_NAME' ${SOURCEDIR}/cmake/googletest.cmake | sed -re 's/.*([0-9]+[.][0-9]+[.][0-9]+).*/\1/')
+    else
+        GMOCK_VERSION=$(grep 'SET(GMOCK_PACKAGE_NAME' ${SOURCEDIR}/unittest/gunit/CMakeLists.txt | sed -re 's/.*([0-9]+[.][0-9]+[.][0-9]+).*/\1/')
+    fi
 
-wget_loop "googletest-release-${GMOCK_VERSION}.zip" "https://github.com/google/googletest/archive/release-${GMOCK_VERSION}.zip"
+    wget_loop "googletest-release-${GMOCK_VERSION}.zip" "https://github.com/google/googletest/archive/release-${GMOCK_VERSION}.zip"
+fi
 
 if [[ ${WITH_BORINGSSL} == "true" ]]; then
     # ------------------------------------------------------------------------------


### PR DESCRIPTION
Build: https://ps80.cd.percona.com/job/percona-server-8.0-pipeline-PS-7823/1/

In 8.0.26, MySQL introduced mysql/mysql-server@93cb589 which breaks our wget_loop and our pipelines will continuously try to download until pipeline timeout exceedes
