### PR TITLE
PS-7876: Correct permissions of built artifacts

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -37,7 +37,7 @@ docker run --rm \
 
     mkdir  /tmp/results
     cp -r /tmp/source_downloads /tmp/results/source_downloads
-    sudo chown -R mysql:mysql /tmp/ps/ || :
+    sudo chown mysql:mysql /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util || : 
     bash -x /tmp/scripts/build-binary /tmp/results /tmp/ps
 
     sudo rm -rf /tmp/ps/results


### PR DESCRIPTION
This was introduced in https://github.com/Percona-Lab/ps-build/commit/e3414b3101fc431c44096b4f01a68c8bd44a3928
And affects current build pipelines

I'm reverting that particular change to unblock percona-server-8.0-param
ZenFS enabled build should be working fine, I'll test it after merge of this change as it's a critical one