### PR TITLE
PS-7899 update supported operating systems for jenkins jobs

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -174,7 +174,7 @@ if [ -f /usr/bin/apt-get ]; then
     done
 
     DIST=$(lsb_release -sc)
-    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'hirsute' ]]; then
+    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'hirsute' ]] && [[ ${DIST} != 'bullseye' ]]; then
         echo "deb http://jenkins.percona.com/apt-repo/ ${DIST} main" > /etc/apt/sources.list.d/percona-dev.list
         wget -q -O - http://jenkins.percona.com/apt-repo/8507EFA5.pub | apt-key add -
         wget -q -O - http://jenkins.percona.com/apt-repo/CD2EFD2A.pub | apt-key add -

--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -175,12 +175,11 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
           - ubuntu:hirsute
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
     builders:
     - trigger-builds:
       - project: percona-server-8.0-pipeline

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -59,7 +59,7 @@ pipeline {
             name: 'TOKUBACKUP_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\nubuntu:hirsute\ndebian:stretch\ndebian:buster',
+            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\nubuntu:hirsute\ndebian:buster\ndebian:bullseye',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -44,12 +44,11 @@
         - centos:6
         - centos:7
         - centos:8
-        - ubuntu:xenial
         - ubuntu:bionic
         - ubuntu:focal
         - ubuntu:hirsute
-        - debian:stretch
         - debian:buster
+        - debian:bullseye
         description: OS version for compilation
     - choice:
         name: JOB_CMAKE

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -56,10 +56,10 @@
                             "centos:7":  { build('centos:7') },
                             "centos:8":  { build('centos:8') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },
-                            "ubuntu:xenial":  { build('ubuntu:xenial') },
                             "ubuntu:focal":  { build('ubuntu:focal') },
-                            "debian:stretch":  { build('debian:stretch') },
+                            "ubuntu:hirsute":  { build('ubuntu:hirsute') },
                             "debian:buster":  { build('debian:buster') },
+                            "debian:bullseye":  { build('debian:bullseye') },
                         )
                     }
                 }

--- a/jenkins/trunk-innodb.yml
+++ b/jenkins/trunk-innodb.yml
@@ -37,11 +37,10 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
       - axis:
          name: label
          type: slave

--- a/jenkins/trunk-max-parts.yml
+++ b/jenkins/trunk-max-parts.yml
@@ -38,11 +38,10 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
       - axis:
          name: label
          type: slave

--- a/jenkins/trunk-secondary.yml
+++ b/jenkins/trunk-secondary.yml
@@ -38,11 +38,10 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
       - axis:
          name: label
          type: slave

--- a/jenkins/trunk-special.yml
+++ b/jenkins/trunk-special.yml
@@ -38,11 +38,10 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
       - axis:
          name: label
          type: slave

--- a/jenkins/trunk.yml
+++ b/jenkins/trunk.yml
@@ -37,11 +37,10 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
       - axis:
          name: label
          type: slave

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -141,11 +141,10 @@
           - centos:6
           - centos:7
           - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
+          - debian:bullseye
     builders:
     - trigger-builds:
       - project: percona-server-8.0-pipeline


### PR DESCRIPTION
1. add: debian:bullseye,
2. remove: ubuntu:xenial, debian:stretch.