### PR TITLE
[PS-7926] Disabled WITH_PACKAGE_FLAGS cmake option for developers builds

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -221,6 +221,7 @@ pushd ${WORKDIR}
         -DWITH_ROUTER=${WITH_ROUTER} \
         -DWITH_MYSQLX=${WITH_MYSQLX} \
         -DWITH_MECAB=${WITH_MECAB} \
+        -DWITH_PACKAGE_FLAGS=OFF \
         -DWITH_SYSTEM_LIBS=ON \
         -DWITH_PROTOBUF=bundled \
         -DWITH_RAPIDJSON=bundled \


### PR DESCRIPTION
This patch adds -DWITH_PACKAGE_FLAGS=OFF flag to cmake run line for dockerized builds