### PR TITLE
PS-7959: Use bundled lz4 lib for PS builds

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -233,6 +233,7 @@ pushd ${WORKDIR}
         -DWITH_NUMA=ON \
         -DWITH_ZLIB=bundled \
         -DWITH_ZSTD=bundled \
+        -DWITH_LZ4=bundled \
         -DWITH_INNODB_MEMCACHED=ON \
         -DENABLE_DOWNLOADS=ON \
         -DDOWNLOAD_ROOT=${DOWNLOAD_DIR} \


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7959

The minimum required lz4 lib version increased to 1.9.3.
Use bundled version for builds as most of supported platforms
will fail this requirement.