### PR TITLE
PS-7955 feature: Enable ZenFS functionality on standard Percona Server packages on Debian 11 and Ubuntu 20.04 Focal

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -234,18 +234,8 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" libre2-dev"
     fi
 
-    if [[ ${DIST} == "hirsute" ]]; then
-        PKGLIST+=" libzbd-dev clang-12 pkg-config make libgflags-dev nvme-cli util-linux fio zbd-utils"
-    fi
-
-    if [[ ${DIST} == "focal" ]]; then
-        PKGLIST+=" clang-12 pkg-config make libgflags-dev nvme-cli util-linux fio"
-        wget_loop 'libzbd-dev.deb' 'http://ua.archive.ubuntu.com/pool/universe/libz/libzbd/libzbd-dev_1.2.0-1_amd64.deb'
-        wget_loop 'libzbd1.deb' 'http://ua.archive.ubuntu.com/pool/universe/libz/libzbd/libzbd1_1.2.0-1_amd64.deb'
-        wget_loop 'zbd-utils.deb' 'http://ua.archive.ubuntu.com/pool/universe/libz/libzbd/zbd-utils_1.2.0-1_amd64.deb'
-        dpkg -i /tmp/source_downloads/libzbd-dev.deb /tmp/source_downloads/libzbd1.deb /tmp/source_downloads/zbd-utils.deb || true
-        apt-get install -fy
-        rm -f /tmp/source_downloads/libzbd-dev.deb /tmp/source_downloads/libzbd1.deb /tmp/source_downloads/zbd-utils.deb
+    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'hirsute' ]] || [[ ${DIST} == 'bullseye' ]]; then
+        PKGLIST+=" libgflags-dev util-linux"
     fi
 
     until apt-get -y install ${PKGLIST}; do

--- a/docker/run-test
+++ b/docker/run-test
@@ -12,7 +12,7 @@ if [[ ${CI_FS_MTR} == 'yes' ]]; then
 fi
 
 if [[ ${ZEN_FS_MTR} == "yes" ]] && [[ ${WITH_ROCKSDB} == "ON" ]]; then
-    if [[ ${DOCKER_OS} == "ubuntu:hirsute" ]] || [[ ${DOCKER_OS} == "ubuntu:focal" ]]; then
+    if [[ ${DOCKER_OS} == "ubuntu:focal" ]] || [[ ${DOCKER_OS} == "ubuntu:hirsute" ]] || [[ ${DOCKER_OS} == "debian:bullseye" ]]; then
         sudo install --owner=root --group=root --mode=+rx $SCRIPTS_DIR/nullblk-zoned /usr/bin/
 
         ZEN_FS_DOCKER_FLAG=''

--- a/local/build-binary
+++ b/local/build-binary
@@ -205,7 +205,7 @@ fi
 # Check ZenFS
 # ------------------------------------------------------------------------------
 if [[ "${ZEN_FS_MTR}" = "yes" ]]; then
-    if [[ ${DOCKER_OS} = "ubuntu-hirsute" ]] || [[ ${DOCKER_OS} = "ubuntu-focal" ]]; then
+    if [[ ${DOCKER_OS} = "ubuntu-focal" ]] || [[ ${DOCKER_OS} = "ubuntu-hirsute" ]] || [[ ${DOCKER_OS} = "debian-bullseye" ]]; then
         CMAKE_OPTS+=" -DROCKSDB_PLUGINS=zenfs -DWITH_ZENFS_UTILITY=ON"
     fi
 fi

--- a/local/test-binary
+++ b/local/test-binary
@@ -191,7 +191,7 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
 fi
 
 if [[ ${ZEN_FS_MTR} = 'yes' ]] && [[ ${WITH_ROCKSDB} = 'ON' ]]; then
-    if [[ ${DOCKER_OS} = 'ubuntu-hirsute' ]] || [[ ${DOCKER_OS} = 'ubuntu-focal' ]]; then
+    if [[ ${DOCKER_OS} = 'ubuntu-focal' ]] || [[ ${DOCKER_OS} = 'ubuntu-hirsute' ]] || [[ ${DOCKER_OS} = 'debian-bullseye' ]]; then
         sudo install --owner=root --group=root --mode=+rx ${WORKDIR_ABS}/PS/runtime_output_directory/zenfs /usr/bin/
 
         sudo rm -rf /tmp/zenfs* || true
@@ -208,7 +208,6 @@ if [[ ${ZEN_FS_MTR} = 'yes' ]] && [[ ${WITH_ROCKSDB} = 'ON' ]]; then
             zenfs list --zbd nullb$nulldevice
 
             blkzone report /dev/nullb$nulldevice
-            zbd report /dev/nullb$nulldevice
         done
         zenfs ls-uuid
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7955

Build scripts modified to support building Percona Server with ZenFS on
Debian 11.1.

Revised the list of required system packages.