### PR TITLE
PS-7955 postfix: Enable ZenFS functionality on standard Percona Server packages on Debian 11 and Ubuntu 20.04 Focal

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -34,6 +34,14 @@ if (
         pipeline_timeout = 22
       }
 
+if (
+    (params.ZEN_FS_MTR == 'yes') &&
+    (params.DOCKER_OS == 'debian:bullseye')
+    ) {
+        LABEL = 'docker-32gb-bullseye'
+        pipeline_timeout = 22
+      }
+
 pipeline {
     parameters {
         string(


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7955

For Debian 11 Bullseye we now use docker-32gb-bullseye image.