### PR TITLE
PS-8083 - Enable localhost IPv6 in test containers

### DIFF
--- a/docker/run-test
+++ b/docker/run-test
@@ -56,6 +56,7 @@ fi
 
 docker run --rm \
     --security-opt seccomp=unconfined \
+    --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
     --mount type=bind,source=${ROOT_DIR},destination=/tmp/ps \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
     ${CI_FS_DOCKER_FLAG} \


### PR DESCRIPTION
***

*Problem:*

IPv6 is disabled by default so tests requiring IPv6 are not executed.

*Solution:*

Enabling the local IPv6 interface for the test containers.

*Notes:*

The command `systctl --write ...` can't not be used as the sysctl
filesystem is mounted in read-only mode.