### PR TITLE
PS-8047 - Set explicitly `-DWITH_FIDO=bundled`

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -226,6 +226,7 @@ pushd ${WORKDIR}
         -DWITH_PROTOBUF=bundled \
         -DWITH_RAPIDJSON=bundled \
         -DWITH_ICU=bundled \
+        -DWITH_FIDO=bundled \
 	-DWITH_READLINE=system \
         -DBUILD_CONFIG=mysql_release \
         -DFEATURE_SET=community \


### PR DESCRIPTION
*Problem:*

8.0.28 in mysql@e8945e28f7a955900fc6cc01bad71f49d63faff9 verifies the
 minimum supported version of the FIDO libraries.

The FIDO version of some platforms are not supported so the compilations
fail with:

```
-- FIDO_VERSION (system) is
CMake Error at cmake/fido2.cmake:156 (MESSAGE):
  FIDO version must be at least 1.4.0, found .

  Please use -DWITH_FIDO=bundled
Call Stack (most recent call first):
  CMakeLists.txt:1783 (MYSQL_CHECK_FIDO)
```

*Solution:*

Use `-DWITH_FIDO=bundled` explicitly.