### PR TITLE
FB8-277 - Create symbolic link /tmp/results/unittest/gunit

### DIFF
--- a/local/test-binary
+++ b/local/test-binary
@@ -20,6 +20,7 @@ rm -fr ${WORKDIR_ABS}/PS
 mkdir -p ${WORKDIR_ABS}/PS/sql
 tar -C ${WORKDIR_ABS}/PS --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz | head -1)
 
+mkdir -p ${WORKDIR_ABS}/unittest && ln -sf ${WORKDIR_ABS}/PS ${WORKDIR_ABS}/unittest/gunit
 ln -sf ${WORKDIR_ABS}/PS/runtime_output_directory ${WORKDIR_ABS}/runtime_output_directory
 ln -sf ${WORKDIR_ABS}/PS/plugin_output_directory ${WORKDIR_ABS}/plugin_output_directory
 ln -sf ${WORKDIR_ABS}/PS/library_output_directory ${WORKDIR_ABS}/library_output_directory


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-277

Some tests are failing because the filesystem is set erroneously as
lowercase becase that directory doesn't exists.

The test FW tries to create a file on that dir and it expects the dir
exists.

Please, mind that we are copying the contents of that directory in the
build script:

```
cp -r ${WORKDIR}/unittest/gunit/*  ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
```