### PR TITLE
PS-7 fix ZENFS_VERSION declaration issue

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -37,11 +37,11 @@ docker run --rm \
 
     mkdir  /tmp/results
     cp -r /tmp/source_downloads /tmp/results/source_downloads
-    sudo chown mysql:mysql /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util || : 
+    sudo chown mysql:mysql /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util /tmp/ps/storage/rocksdb/rocksdb_plugins/zenfs/fs || :
     bash -x /tmp/scripts/build-binary /tmp/results /tmp/ps
 
     sudo rm -rf /tmp/ps/results
     sudo mkdir /tmp/ps/results
     sudo mv /tmp/results/*.tar.gz /tmp/ps/results/
-    sudo chown -R $(id -u):$(id -g) /tmp/ps/results /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util
+    sudo chown -R $(id -u):$(id -g) /tmp/ps/results /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util /tmp/ps/storage/rocksdb/rocksdb_plugins/zenfs/fs
 "


### PR DESCRIPTION
Issue: execution of "./generate-version.sh" via cmake EXECUTE_PROCESS
inside the docker container resulted in
"/tmp/ps/storage/rocksdb/rocksdb_plugins/zenfs/fs/version.h: Permission denied"
due to the lack of permissions to update files in docker mounted volumes.

Fix: change permissions to update files in the affected folder.