### PR TITLE
FB8-273 PS-8236 add libudev libfido2 build deps

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -23,6 +23,11 @@ if [ -f /usr/bin/yum ]; then
     curl https://jenkins.percona.com/downloads/cent6/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
   fi
 
+  if grep -q 'CentOS.* 8\.' /etc/redhat-release; then
+      sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+      sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+  fi
+
   until yum -y update; do
     yum clean all
     echo "waiting"
@@ -78,7 +83,7 @@ if [ -f /usr/bin/yum ]; then
     perl-JSON MySQL-python perl-Digest perl-Digest-MD5 \
     numactl-devel git which make rpm-build ccache libtool redhat-lsb-core sudo libasan lz4-devel \
     libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq openssl perl-XML-Simple libcurl-devel perl-Test-Simple \
-    cyrus-sasl-devel cyrus-sasl-scram krb5-devel \
+    cyrus-sasl-devel cyrus-sasl-scram krb5-devel libudev-devel \
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -174,7 +179,7 @@ if [ -f /usr/bin/apt-get ]; then
     done
 
     DIST=$(lsb_release -sc)
-    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'hirsute' ]] && [[ ${DIST} != 'bullseye' ]]; then
+    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'jammy' ]] && [[ ${DIST} != 'hirsute' ]] && [[ ${DIST} != 'bullseye' ]]; then
         echo "deb http://jenkins.percona.com/apt-repo/ ${DIST} main" > /etc/apt/sources.list.d/percona-dev.list
         wget -q -O - http://jenkins.percona.com/apt-repo/8507EFA5.pub | apt-key add -
         wget -q -O - http://jenkins.percona.com/apt-repo/CD2EFD2A.pub | apt-key add -
@@ -193,7 +198,7 @@ if [ -f /usr/bin/apt-get ]; then
         debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
         tzdata golang libunwind-dev zstd python3-mysqldb libdbi-perl libdbd-mysql-perl \
         jq openssl libxml-simple-perl \
-        libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev \
+        libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev libudev-dev \
     "
 
     # PS-7834: 8.0.26 requires GCC 8 on bionic
@@ -234,7 +239,7 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" libre2-dev"
     fi
 
-    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'hirsute' ]] || [[ ${DIST} == 'bullseye' ]]; then
+    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'hirsute' ]] || [[ ${DIST} == 'bullseye' ]]; then
         PKGLIST+=" libgflags-dev util-linux"
     fi
 

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -57,6 +57,7 @@
                             "centos:8":  { build('centos:8') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },
                             "ubuntu:focal":  { build('ubuntu:focal') },
+                            "ubuntu:jammy":  { build('ubuntu:jammy') },
                             "ubuntu:hirsute":  { build('ubuntu:hirsute') },
                             "debian:buster":  { build('debian:buster') },
                             "debian:bullseye":  { build('debian:bullseye') },

--- a/local/build-binary
+++ b/local/build-binary
@@ -234,6 +234,7 @@ pushd ${WORKDIR}
         -DWITH_ZLIB=bundled \
         -DWITH_ZSTD=bundled \
         -DWITH_LZ4=bundled \
+        -DWITH_FIDO=bundled \
         -DWITH_INNODB_MEMCACHED=ON \
         -DENABLE_DOWNLOADS=ON \
         -DDOWNLOAD_ROOT=${DOWNLOAD_DIR} \


### PR DESCRIPTION
1. Add "-DWITH_FIDO=bundled" CMAKE flag to build-binary, since
libfido2 devel pkg is available only for some recent OS(rpm/deb).

2. Add "libudev" devel pkg(required by fido2).

3. Add Jammy support.