### PR TITLE
PS-8185 - Update devtoolset for 8.0.29

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -91,6 +91,11 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET10+=" gcc-toolset-10-gcc-c++ gcc-toolset-10-binutils gcc-toolset-10-annobin"
         PKGLIST_DEVTOOLSET10+=" gcc-toolset-10-valgrind gcc-toolset-10-valgrind-devel gcc-toolset-10-libatomic-devel"
         PKGLIST_DEVTOOLSET10+=" gcc-toolset-10-libasan-devel gcc-toolset-10-libubsan-devel"
+
+        # Next packages are required by 8.0.29
+        PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-gcc-c++ gcc-toolset-11-binutils gcc-toolset-11-annobin"
+        PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-valgrind gcc-toolset-11-valgrind-devel gcc-toolset-11-libatomic-devel"
+        PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-libasan-devel gcc-toolset-11-libubsan-devel"
     fi
 
     if [[ ${RHVER} -eq 7 ]]; then
@@ -98,6 +103,11 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET10+=" devtoolset-10-gcc-c++ devtoolset-10-binutils"
         PKGLIST_DEVTOOLSET10+=" devtoolset-10-valgrind devtoolset-10-valgrind-devel devtoolset-10-libatomic-devel"
         PKGLIST_DEVTOOLSET10+=" devtoolset-10-libasan-devel devtoolset-10-libubsan-devel"
+
+        # Next packages are required by 8.0.29
+        PKGLIST_DEVTOOLSET11+=" devtoolset-11-gcc-c++ devtoolset-11-binutils"
+        PKGLIST_DEVTOOLSET11+=" devtoolset-11-valgrind devtoolset-11-valgrind-devel devtoolset-11-libatomic-devel"
+        PKGLIST_DEVTOOLSET11+=" devtoolset-11-libasan-devel devtoolset-11-libubsan-devel"
     fi
 
     if [[ ${RHVER} != 6 ]]; then
@@ -134,13 +144,13 @@ if [ -f /usr/bin/yum ]; then
     done
 
     if [[ ${RHVER} -eq 7 ]]; then
-        until yum -y --enablerepo=centos-sclo-rh-testing install ${PKGLIST_DEVTOOLSET10}; do
+        until yum -y --enablerepo=centos-sclo-rh-testing install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11}; do
             echo "waiting"
             sleep 1
         done
     elif [[ ${RHVER} -eq 8 ]]; then
         yum -y install centos-release-stream
-        until yum -y install ${PKGLIST_DEVTOOLSET10}; do
+        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11}; do
             echo "waiting"
             sleep 1
         done


### PR DESCRIPTION
Oracle has updated the the compiler in 8.0.29.

https://github.com/mysql/mysql-server/commit/1c18f363a92f97c7f0e7a4c6688b44a8b9ea1c19

Unfortunately, in `install-deps` there is no way of knowing what PS
version we are installing dependencies for. Therefore, we need to
install the dependencies for 8.0.29 and the previous versions.
