### PR TITLE
ENG-1132 docker: mount /dev/shm for mtr tests

### DIFF
--- a/docker/run-test
+++ b/docker/run-test
@@ -57,6 +57,7 @@ fi
 docker run --rm \
     --security-opt seccomp=unconfined \
     --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+    --volume /dev/shm:/dev/shm \
     --mount type=bind,source=${ROOT_DIR},destination=/tmp/ps \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
     ${CI_FS_DOCKER_FLAG} \


### PR DESCRIPTION
Issue: While running MTR tests with mysql-test-run.pl using "--mem" option
inside docker container, the /var/ folder is created in /dev/shm.
By default /dev/shm inside docker container is limited by 64MB,
which is not enough for running tests.

Fix: add "--volume /dev/shm:/dev/shm" option to use host's /dev/shm