### PR TITLE
ENG-1135 - Remove CentOS 6 from supported OS for PS 8.0 Jenkins jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ git clone https://github.com/Percona-Lab/ps-build
 cd ps-build
 ./local/checkout
 
-./docker/run-build centos:6
-./docker/run-test centos:6
+./docker/run-build centos:7
+./docker/run-test centos:7
 ```
 
 ## Docker debug
@@ -14,7 +14,7 @@ git clone https://github.com/Percona-Lab/ps-build
 cd ps-build
 ./local/checkout
 
-./docker/run-build-debug centos:6
+./docker/run-build-debug centos:7
 ```
 
 # Local way

--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -172,7 +172,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -75,7 +75,7 @@ pipeline {
             name: 'TOKUBACKUP_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\nubuntu:hirsute\ndebian:buster\ndebian:bullseye',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\nubuntu:hirsute\ndebian:buster\ndebian:bullseye',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -41,7 +41,6 @@
     - choice:
         name: DOCKER_OS
         choices:
-        - centos:6
         - centos:7
         - centos:8
         - ubuntu:bionic

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -51,8 +51,6 @@
                 stage('Build') {
                     steps {
                         parallel(
-                            "i386/centos:6":  { build('i386/centos:6') },
-                            "centos:6":  { build('centos:6') },
                             "centos:7":  { build('centos:7') },
                             "centos:8":  { build('centos:8') },
                             "ubuntu:bionic":  { build('ubuntu:bionic') },

--- a/jenkins/repeat-trunk.yml
+++ b/jenkins/repeat-trunk.yml
@@ -128,7 +128,7 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
+          - centos:7
     builders:
     - trigger-builds:
       - project: percona-server-8.0-pipeline

--- a/jenkins/trunk-innodb.yml
+++ b/jenkins/trunk-innodb.yml
@@ -34,7 +34,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/jenkins/trunk-max-parts.yml
+++ b/jenkins/trunk-max-parts.yml
@@ -35,7 +35,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/jenkins/trunk-secondary.yml
+++ b/jenkins/trunk-secondary.yml
@@ -35,7 +35,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/jenkins/trunk-special.yml
+++ b/jenkins/trunk-special.yml
@@ -35,7 +35,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/jenkins/trunk.yml
+++ b/jenkins/trunk.yml
@@ -34,7 +34,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -138,7 +138,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic


### PR DESCRIPTION
The reasons for removing it are:

- CentOS 6 is not officially supported.

- The cmake version of CentOS 6 is not supported by 8.0.28-20:

```
CMake Error at extra/opensslpp/CMakeLists.txt:17 (cmake_minimum_required):
  CMake 3.8 or higher is required.  You are running version 3.6.1
```
