### PR TITLE
PS-7 fix: remove Ubuntu Hirsuite from the available platforms

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -204,7 +204,7 @@ if [ -f /usr/bin/apt-get ]; then
     done
 
     DIST=$(lsb_release -sc)
-    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'jammy' ]] && [[ ${DIST} != 'hirsute' ]] && [[ ${DIST} != 'bullseye' ]]; then
+    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'jammy' ]] && [[ ${DIST} != 'bullseye' ]]; then
         echo "deb http://jenkins.percona.com/apt-repo/ ${DIST} main" > /etc/apt/sources.list.d/percona-dev.list
         wget -q -O - http://jenkins.percona.com/apt-repo/8507EFA5.pub | apt-key add -
         wget -q -O - http://jenkins.percona.com/apt-repo/CD2EFD2A.pub | apt-key add -
@@ -264,7 +264,7 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" libre2-dev"
     fi
 
-    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'hirsute' ]] || [[ ${DIST} == 'bullseye' ]]; then
+    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]]; then
         PKGLIST+=" libgflags-dev util-linux"
     fi
 

--- a/docker/run-test
+++ b/docker/run-test
@@ -12,7 +12,7 @@ if [[ ${CI_FS_MTR} == 'yes' ]]; then
 fi
 
 if [[ ${ZEN_FS_MTR} == "yes" ]] && [[ ${WITH_ROCKSDB} == "ON" ]]; then
-    if [[ ${DOCKER_OS} == "ubuntu:focal" ]] || [[ ${DOCKER_OS} == "ubuntu:hirsute" ]] || [[ ${DOCKER_OS} == "debian:bullseye" ]]; then
+    if [[ ${DOCKER_OS} == "ubuntu:focal" ]] || [[ ${DOCKER_OS} == "debian:bullseye" ]]; then
         sudo install --owner=root --group=root --mode=+rx $SCRIPTS_DIR/nullblk-zoned /usr/bin/
 
         ZEN_FS_DOCKER_FLAG=''

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -20,14 +20,6 @@ if (
 
 if (
     (params.ZEN_FS_MTR == 'yes') &&
-    (params.DOCKER_OS == 'ubuntu:hirsute')
-    ) { 
-        LABEL = 'docker-32gb-hirsute'
-        pipeline_timeout = 22
-      }
-
-if (
-    (params.ZEN_FS_MTR == 'yes') &&
     (params.DOCKER_OS == 'ubuntu:focal')
     ) { 
         LABEL = 'docker-32gb-focal'
@@ -75,7 +67,7 @@ pipeline {
             name: 'TOKUBACKUP_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\nubuntu:hirsute\ndebian:buster\ndebian:bullseye',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster\ndebian:bullseye',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -45,7 +45,6 @@
         - centos:8
         - ubuntu:bionic
         - ubuntu:focal
-        - ubuntu:hirsute
         - debian:buster
         - debian:bullseye
         description: OS version for compilation

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -57,7 +57,6 @@
                             "ubuntu:bionic":   { build('ubuntu:bionic') },
                             "ubuntu:focal":    { build('ubuntu:focal') },
                             "ubuntu:jammy":    { build('ubuntu:jammy') },
-                            "ubuntu:hirsute":  { build('ubuntu:hirsute') },
                             "debian:buster":   { build('debian:buster') },
                             "debian:bullseye": { build('debian:bullseye') },
                         )

--- a/local/build-binary
+++ b/local/build-binary
@@ -205,7 +205,7 @@ fi
 # Check ZenFS
 # ------------------------------------------------------------------------------
 if [[ "${ZEN_FS_MTR}" = "yes" ]]; then
-    if [[ ${DOCKER_OS} = "ubuntu-focal" ]] || [[ ${DOCKER_OS} = "ubuntu-hirsute" ]] || [[ ${DOCKER_OS} = "debian-bullseye" ]]; then
+    if [[ ${DOCKER_OS} = "ubuntu-focal" ]] || [[ ${DOCKER_OS} = "debian-bullseye" ]]; then
         CMAKE_OPTS+=" -DROCKSDB_PLUGINS=zenfs -DWITH_ZENFS_UTILITY=ON"
     fi
 fi
@@ -226,7 +226,7 @@ pushd ${WORKDIR}
         -DWITH_PROTOBUF=bundled \
         -DWITH_RAPIDJSON=bundled \
         -DWITH_ICU=bundled \
-	-DWITH_READLINE=system \
+        -DWITH_READLINE=system \
         -DBUILD_CONFIG=mysql_release \
         -DFEATURE_SET=community \
         -DWITH_PAM=ON \

--- a/local/test-binary
+++ b/local/test-binary
@@ -192,7 +192,7 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
 fi
 
 if [[ ${ZEN_FS_MTR} = 'yes' ]] && [[ ${WITH_ROCKSDB} = 'ON' ]]; then
-    if [[ ${DOCKER_OS} = 'ubuntu-focal' ]] || [[ ${DOCKER_OS} = 'ubuntu-hirsute' ]] || [[ ${DOCKER_OS} = 'debian-bullseye' ]]; then
+    if [[ ${DOCKER_OS} = 'ubuntu-focal' ]] || [[ ${DOCKER_OS} = 'debian-bullseye' ]]; then
         sudo install --owner=root --group=root --mode=+rx ${WORKDIR_ABS}/PS/runtime_output_directory/zenfs /usr/bin/
 
         sudo rm -rf /tmp/zenfs* || true


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7

Outdated non-LTS Ubuntu 21.04 Hirsuite, previously used for ZenFS testing on earlier stages, comppletely removed from the list of available platforms.