### PR TITLE
PS-7 fix: Centos 6 removal + ZenFS on OL9

### DIFF
--- a/docker/Dockerfile.inc
+++ b/docker/Dockerfile.inc
@@ -4,6 +4,6 @@ COPY install-deps /tmp/install-deps
 RUN /tmp/install-deps
 
 RUN echo "mysql ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers \
-    && groupadd -g 27 -o -r mysql \
-    && useradd -M -N -g mysql -o -r -d /var/lib/mysql -s /bin/false -c "Percona Server" -u 27 mysql
+    && groupadd -g 1001 -o -r mysql \
+    && useradd -M -N -g mysql -o -r -d /var/lib/mysql -s /bin/false -c "Percona Server" -u 1001 mysql
 USER mysql

--- a/docker/install-deps
+++ b/docker/install-deps
@@ -19,10 +19,6 @@ if [ -f /usr/bin/yum ]; then
   RHVER="$(rpm --eval %rhel)"
   rpm --eval %_arch > /etc/yum/vars/basearch
 
-  if [[ ${RHVER} -eq 6 ]]; then
-    curl https://jenkins.percona.com/downloads/cent6/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
-  fi
-
   if grep -q 'CentOS.* 8\.' /etc/redhat-release; then
       sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
       sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
@@ -40,10 +36,6 @@ if [ -f /usr/bin/yum ]; then
     echo "waiting"
     sleep 1
   done
-  if [[ ${RHVER} -eq 6 ]]; then
-    rm /etc/yum.repos.d/epel-testing.repo
-    curl https://jenkins.percona.com/downloads/cent6/centos6-epel-eol.repo --output /etc/yum.repos.d/epel.repo
-  fi
 
   if [[ ${RHVER} -eq 8 ]]; then
       PKGLIST+=" dnf-utils"
@@ -72,10 +64,6 @@ if [ -f /usr/bin/yum ]; then
       echo "waiting"
       sleep 1
     done
-    if [[ ${RHVER} -eq 6 ]]; then
-      curl https://jenkins.percona.com/downloads/cent6/centos6-scl-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl.repo
-      curl https://jenkins.percona.com/downloads/cent6/centos6-scl-rh-eol.repo --output /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    fi
   fi
   until yum -y install ${PKGLIST}; do
     echo "waiting"
@@ -89,13 +77,17 @@ if [ -f /usr/bin/yum ]; then
 
   PKGLIST=" \
     gcc-c++ gperf ncurses-devel perl readline-devel openssl-devel jemalloc zip unzip \
-    time zlib-devel libaio-devel bison cmake pam-devel jemalloc-devel valgrind re2-devel \
+    time zlib-devel libaio-devel bison cmake pam-devel jemalloc-devel valgrind \
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
     perl-JSON perl-Digest perl-Digest-MD5 \
     numactl-devel git which make rpm-build ccache libtool sudo libasan lz4-devel \
     libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq openssl perl-XML-Simple libcurl-devel perl-Test-Simple \
-    cyrus-sasl-devel cyrus-sasl-scram krb5-devel libudev-devel \
+    cyrus-sasl-devel cyrus-sasl-scram krb5-devel libudev-devel python3-pip python3-devel libevent-devel \
     "
+
+    if [[ ${RHVER} -eq 9 ]]; then
+        PKGLIST+=" gflags-devel util-linux libtirpc-devel rpcgen"
+    fi
 
     if [[ ${RHVER} -lt 9 ]]; then
         PKGLIST+=" MySQL-python redhat-lsb-core"
@@ -125,23 +117,7 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET11+=" devtoolset-11-libasan-devel devtoolset-11-libubsan-devel"
     fi
 
-    if [[ ${RHVER} != 6 ]]; then
-        PKGLIST+=" python3-pip python3-devel"
-    fi
-
 # Percona-Server
-    if [[ ${RHVER} -eq 6 ]]; then
-        wget -O /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
-        wget -O /etc/pki/rpm-gpg/RPM-GPG-KEY-cern https://raw.githubusercontent.com/cms-sw/cms-docker/master/slc6/RPM-GPG-KEY-cern
-        PKGLIST+=" devtoolset-2-gcc-c++ devtoolset-2-binutils"
-        PKGLIST+=" devtoolset-2-libasan-devel"
-        PKGLIST+=" devtoolset-2-valgrind devtoolset-2-valgrind-devel"
-        PKGLIST+=" libevent2-devel python-argparse"
-    fi
-
-    if [[ ${RHVER} -gt 6 ]]; then
-        PKGLIST+=" libevent-devel"
-    fi
 
 #   Percona-Server 8.0
     if [[ ${RHVER} -lt 8 ]]; then
@@ -176,13 +152,11 @@ if [ -f /usr/bin/yum ]; then
         ln -fs /usr/bin/python3 /usr/bin/python
     fi
 
-    if [[ ${RHVER} != 6 ]]; then
-        # Install mysqlclient by pip as there's no candidate in repositories
-        if [[ ${RHVER} -eq 7 ]]; then
-            source /opt/rh/devtoolset-7/enable
-        fi
-        pip3 install mysqlclient
+    # Install mysqlclient by pip as there's no candidate in repositories
+    if [[ ${RHVER} -eq 7 ]]; then
+        source /opt/rh/devtoolset-7/enable
     fi
+    pip3 install mysqlclient
 
 #   this is workaround for https://bugs.mysql.com/bug.php?id=95222 as soon as the issue is fixed we need to remove it 
     if [ -f '/anaconda-post.log' ]; then
@@ -204,11 +178,6 @@ if [ -f /usr/bin/apt-get ]; then
     done
 
     DIST=$(lsb_release -sc)
-    if [[ ${DIST} != 'focal' ]] && [[ ${DIST} != 'jammy' ]] && [[ ${DIST} != 'bullseye' ]]; then
-        echo "deb http://jenkins.percona.com/apt-repo/ ${DIST} main" > /etc/apt/sources.list.d/percona-dev.list
-        wget -q -O - http://jenkins.percona.com/apt-repo/8507EFA5.pub | apt-key add -
-        wget -q -O - http://jenkins.percona.com/apt-repo/CD2EFD2A.pub | apt-key add -
-    fi
 
     until apt-get update; do
         sleep 1
@@ -223,7 +192,7 @@ if [ -f /usr/bin/apt-get ]; then
         debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
         tzdata golang libunwind-dev zstd python3-mysqldb libdbi-perl libdbd-mysql-perl \
         jq openssl libxml-simple-perl \
-        libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev libudev-dev \
+        libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev libudev-dev libzstd-dev libsys-meminfo-perl \
     "
 
     # PS-7834: 8.0.26 requires GCC 8 on bionic
@@ -231,40 +200,7 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" gcc-8 g++-8"
     fi
 
-    DISTRIBUTOR_ID=$(lsb_release -i -s)
-    RELEASE=$(lsb_release -r -s)
-    if [[ ${DISTRIBUTOR_ID} == Ubuntu ]] && [[ $(echo "${RELEASE} >= 18.0" | bc -l) == 1 ]]; then
-        PKGLIST+=" libasan5"
-    fi
-
-    if [[ ${RELEASE} > "16.0" ]]; then
-        PKGLIST+=" libre2-dev"
-    fi
-
-    # On Ubuntu install zstd/libsys-meminfo-perl only for Xenial (16.X) and higher
-    if [[ ${DISTRIBUTOR_ID} == Ubuntu ]] && [[ $(echo "${RELEASE} >= 16.0" | bc -l) == 1 ]]; then
-        PKGLIST+=" libsys-meminfo-perl"
-
-        if [[ $(echo "${RELEASE} >= 18.0" | bc -l) == 1 ]]; then
-            # libzstd-dev for Bionic and higher
-            PKGLIST+=" libzstd-dev libboost-dev libatomic1"
-        else
-            # libzstd1-dev for Xenial
-            PKGLIST+=" libzstd1-dev"
-        fi
-    fi
-
-    # On Debian install zstd/perl-Sys-MemInfo only for Stretch (9.X) and higher
-    if [[ ${DISTRIBUTOR_ID} == Debian ]] && [[ $(echo "${RELEASE} >= 9.0" | bc -l) == 1 ]]; then
-        PKGLIST+=" libzstd-dev libsys-meminfo-perl"
-    fi
-
-    # For Debian buster install libre2-dev
-    if [[ ${DISTRIBUTOR_ID} == Debian ]] && [[ $(echo "${RELEASE} >= 10" | bc -l) == 1 ]]; then
-        PKGLIST+=" libre2-dev"
-    fi
-
-    if [[ ${DIST} == 'focal' ]] || [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]]; then
+    if [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]]; then
         PKGLIST+=" libgflags-dev util-linux"
     fi
 
@@ -284,13 +220,6 @@ fi
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then
     git clone https://github.com/stewartsmith/libeatmydata /tmp/libeatmydata
     pushd /tmp/libeatmydata
-        # PS-7639: Needed for CentOS 6 because of ancient autoconf
-        if [ -f /usr/bin/yum ]; then
-            RHVER="$(rpm --eval %rhel)"
-            if [[ ${RHVER} -eq 6 ]]; then
-                git checkout df7ddeb0345104f25b5b7bb154bc6a008c8c8404
-            fi
-        fi
         autoreconf --force --install
         ./configure
         make
@@ -299,6 +228,9 @@ if [ ! -f /usr/local/lib/libeatmydata.so ]; then
     rm -rf /tmp/libeatmydata
 fi
 
+# getting rid of the "fatal: detected dubious ownership in repository at ..." error
+sudo git config --system --add safe.directory '*'
+
 # PS-7159 remove localhost from ipv6 
 sed -re "s/^(::1.*)\slocalhost\b(.*)$/\1 \2/g" /etc/hosts 1<> /etc/hosts
 
@@ -306,8 +238,8 @@ sed -re "s/^(::1.*)\slocalhost\b(.*)$/\1 \2/g" /etc/hosts 1<> /etc/hosts
 # boost 1.59.0 needed for percona-server 5.7
 wget_loop 'boost_1_59_0.tar.gz' 'http://downloads.sourceforge.net/boost/boost/1.59.0/boost_1_59_0.tar.gz'
 
-# boost 1.67.0 needed for percona-server 8.0
-wget_loop 'boost_1_67_0.tar.gz' 'http://downloads.sourceforge.net/boost/boost/1.67.0/boost_1_67_0.tar.gz'
+# boost 1.77.0 needed for percona-server 8.0
+wget_loop 'boost_1_77_0.tar.bz2' 'http://downloads.sourceforge.net/boost/boost/1.77.0/boost_1_77_0.tar.bz2'
 
-# googletest 1.8.0 needed for percona-server versions 5.6 to 8.0
+# googletest 1.8.0 needed for percona-server versions 5.6 and 5.7
 wget_loop 'googletest-release-1.8.0.zip' 'https://github.com/google/googletest/archive/release-1.8.0.zip'

--- a/docker/run-build
+++ b/docker/run-build
@@ -43,5 +43,6 @@ docker run --rm \
     sudo rm -rf /tmp/ps/results
     sudo mkdir /tmp/ps/results
     sudo mv /tmp/results/*.tar.gz /tmp/ps/results/
-    sudo chown -R $(id -u):$(id -g) /tmp/ps /tmp/ps/results /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util /tmp/ps/storage/rocksdb/rocksdb_plugins/zenfs/fs
+    sudo chown -R $(id -u):$(id -g) /tmp/ps/results
+    sudo chown $(id -u):$(id -g) /tmp/ps /tmp/ps/mysql-test/collections /tmp/ps/storage/rocksdb/rocksdb/util /tmp/ps/rocksdb/util /tmp/ps/storage/rocksdb/rocksdb_plugins/zenfs/fs || :
 "

--- a/docker/run-test
+++ b/docker/run-test
@@ -12,7 +12,7 @@ if [[ ${CI_FS_MTR} == 'yes' ]]; then
 fi
 
 if [[ ${ZEN_FS_MTR} == "yes" ]] && [[ ${WITH_ROCKSDB} == "ON" ]]; then
-    if [[ ${DOCKER_OS} == "ubuntu:focal" ]] || [[ ${DOCKER_OS} == "debian:bullseye" ]]; then
+    if [[ ${DOCKER_OS} == "ubuntu:jammy" ]] || [[ ${DOCKER_OS} == "debian:bullseye" ]] || [[ ${DOCKER_OS} == "oraclelinux:9" ]]; then
         sudo install --owner=root --group=root --mode=+rx $SCRIPTS_DIR/nullblk-zoned /usr/bin/
 
         ZEN_FS_DOCKER_FLAG=''
@@ -21,14 +21,14 @@ if [[ ${ZEN_FS_MTR} == "yes" ]] && [[ ${WITH_ROCKSDB} == "ON" ]]; then
             sudo rmdir /sys/kernel/config/nullb/nullb$nulldevice || true 
 
             sudo nullblk-zoned $nulldevice 512 128 124 0 32 12 12
-            sudo chown 27:27 /dev/nullb$nulldevice
+            sudo chown 1001:1001 /dev/nullb$nulldevice
             sudo chmod 660 /dev/nullb$nulldevice
             ZEN_FS_DOCKER_FLAG+=" --device=/dev/nullb$nulldevice"
         done
     fi
 fi
 
-if [[ "${KEYRING_VAULT_MTR}" == 'yes' ]] && [[ ${DOCKER_OS} != 'centos:6' ]] && [[ ${DOCKER_OS} != 'i386/centos:6' ]]; then
+if [[ "${KEYRING_VAULT_MTR}" == 'yes' ]]; then
     if [[ $(docker network list | grep bridge-vault) != *bridge-vault* ]]; then
         docker network create bridge-vault
     fi
@@ -44,12 +44,12 @@ if [[ "${KEYRING_VAULT_MTR}" == 'yes' ]] && [[ ${DOCKER_OS} != 'centos:6' ]] && 
     BOOTSTRAP_PROD_V1="$(bash $SCRIPTS_DIR/bootstrap-vault --mode=prod --version="${KEYRING_VAULT_V1_VERSION}" --alias=v1 --port="9300")"
     export VAULT_V1_PROD_ROOT_TOKEN=$(echo "$BOOTSTRAP_PROD_V1" | grep "Production token" | awk -F ':' '{print $2}' | xargs)
     export VAULT_V1_PROD_MTR_TOKEN=$(echo "$BOOTSTRAP_PROD_V1" | grep "MTR token" | awk -F ':' '{print $2}' | xargs)
-    sudo install --owner=27 --group=27 /tmp/vault.d-v1-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v1-ca.pem
+    sudo install --owner=1001 --group=1001 /tmp/vault.d-v1-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v1-ca.pem
 
     BOOTSTRAP_PROD_V2="$(bash $SCRIPTS_DIR/bootstrap-vault --mode=prod --version="${KEYRING_VAULT_V2_VERSION}" --alias=v2 --port="9500")"
     export VAULT_V2_PROD_ROOT_TOKEN=$(echo "$BOOTSTRAP_PROD_V2" | grep "Production token" | awk -F ':' '{print $2}' | xargs)
     export VAULT_V2_PROD_MTR_TOKEN=$(echo "$BOOTSTRAP_PROD_V2" | grep "MTR token" | awk -F ':' '{print $2}' | xargs)
-    sudo install --owner=27 --group=27 /tmp/vault.d-v2-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v2-ca.pem
+    sudo install --owner=1001 --group=1001 /tmp/vault.d-v2-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v2-ca.pem
 
     VAULT_DOCKER_FLAG="--network bridge-vault"
 fi

--- a/jenkins/asan-param.yml
+++ b/jenkins/asan-param.yml
@@ -140,7 +140,7 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - ubuntu:focal
+          - ubuntu:jammy
     builders:
     - trigger-builds:
       - project: percona-server-8.0-pipeline

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -20,15 +20,23 @@ if (
 
 if (
     (params.ZEN_FS_MTR == 'yes') &&
-    (params.DOCKER_OS == 'ubuntu:focal')
+    (params.DOCKER_OS == 'ubuntu:jammy')
     ) { 
-        LABEL = 'docker-32gb-focal'
+        LABEL = 'docker-32gb-bullseye'
         pipeline_timeout = 22
       }
 
 if (
     (params.ZEN_FS_MTR == 'yes') &&
     (params.DOCKER_OS == 'debian:bullseye')
+    ) {
+        LABEL = 'docker-32gb-bullseye'
+        pipeline_timeout = 22
+      }
+
+if (
+    (params.ZEN_FS_MTR == 'yes') &&
+    (params.DOCKER_OS == 'oraclelinux:9')
     ) {
         LABEL = 'docker-32gb-bullseye'
         pipeline_timeout = 22
@@ -286,7 +294,7 @@ pipeline {
                                     until aws s3 cp --no-progress s3://ps-build-cache/${BUILD_TAG}/binary.tar.gz ./sources/results/binary.tar.gz; do
                                         sleep 5
                                     done
-                                    
+
                                     if [ -f /usr/bin/yum ]; then
                                         sudo yum -y install jq gflags-devel
                                     else
@@ -298,8 +306,8 @@ pipeline {
                                             sudo dd if=/dev/zero of=/mnt/ci_disk_\$CMAKE_BUILD_TYPE.img bs=1G count=10
                                             sudo /sbin/mkfs.vfat /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img
                                             sudo mkdir -p /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE
-                                            sudo mount -o loop -o uid=27 -o gid=27 -o check=r /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE
-                                        fi                                
+                                            sudo mount -o loop -o uid=1001 -o gid=1001 -o check=r /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE
+                                        fi
                                     fi
 
                                     echo Test: \$(date -u "+%s")

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -138,14 +138,7 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:7
-          - centos:8
-          - oraclelinux:9
-          - ubuntu:bionic
-          - ubuntu:focal
           - ubuntu:jammy
-          - debian:buster
-          - debian:bullseye
     builders:
     - trigger-builds:
       - project: percona-server-8.0-pipeline

--- a/local/build-binary
+++ b/local/build-binary
@@ -53,16 +53,11 @@ wget_loop() {
 }
 
 BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
-wget_loop "boost_${BOOST_VERSION}.tar.gz" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+wget_loop "boost_${BOOST_VERSION}.tar.bz2" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.bz2"
 
-if grep -q GMOCK_PACKAGE_NAME ${SOURCEDIR}/cmake/googletest.cmake || grep -q GMOCK_PACKAGE_NAME ${SOURCEDIR}/unittest/gunit/CMakeLists.txt; then
-    if [ -f "${SOURCEDIR}/cmake/googletest.cmake" ]; then
-        GMOCK_VERSION=$(grep 'SET(GMOCK_PACKAGE_NAME' ${SOURCEDIR}/cmake/googletest.cmake | sed -re 's/.*([0-9]+[.][0-9]+[.][0-9]+).*/\1/')
-    else
-        GMOCK_VERSION=$(grep 'SET(GMOCK_PACKAGE_NAME' ${SOURCEDIR}/unittest/gunit/CMakeLists.txt | sed -re 's/.*([0-9]+[.][0-9]+[.][0-9]+).*/\1/')
-    fi
-
-    wget_loop "googletest-release-${GMOCK_VERSION}.zip" "https://github.com/google/googletest/archive/release-${GMOCK_VERSION}.zip"
+RHVER=0
+if [[ -f /etc/redhat-release ]]; then
+    RHVER="$(rpm --eval %rhel)"
 fi
 
 if [[ ${WITH_BORINGSSL} == "true" ]]; then
@@ -73,9 +68,8 @@ if [[ ${WITH_BORINGSSL} == "true" ]]; then
     git clone https://github.com/google/boringssl.git boringssl_sources
     mkdir boringssl_sources/bin
     cd boringssl_sources/bin
-    if [[ -f /etc/redhat-release ]]; then
-        RHVER="$(rpm --eval %rhel)"
-        if [[ ${RHVER} == 7 ]]; then
+    if [[ ${RHVER} -ne 0 ]]; then
+        if [[ ${RHVER} -eq 7 ]]; then
             source /opt/rh/go-toolset-7/enable
         fi
         BORING_SSL_CMAKE=/usr/bin/cmake3
@@ -113,14 +107,6 @@ if [[ "${ANALYZER_OPTS}" = *WITH_VALGRIND=ON* ]]; then
     BUILD_COMMENT+="-valgrind"
 fi
 
-OS_VERSION=$(lsb_release -d -s)
-if [[ "${OS_VERSION}" = *"CentOS release 6."* ]] && [[ "${CMAKE_BUILD_TYPE}" = "RelWithDebInfo" ]]; then
-    MYSQL_MAINTAINER_MODE="OFF"
-else
-    MYSQL_MAINTAINER_MODE="ON"
-fi
-
-
 # ------------------------------------------------------------------------------
 # set version
 # ------------------------------------------------------------------------------
@@ -142,12 +128,8 @@ TOKUDB_BACKUP_VERSION="${MYSQL_VERSION}${MYSQL_VERSION_EXTRA}"
 PRODUCT_FULL="Percona-Server-${MYSQL_VERSION}-${PERCONA_SERVER_VERSION}${BUILD_COMMENT}-${TAG}$(uname -s)${DIST_NAME}.${TARGET_ARCH}${SSL_VER}"
 COMMENT="Percona Server (GPL), Release ${MYSQL_VERSION_EXTRA#-}, Revision ${REVISION:-}${BUILD_COMMENT}"
 
-if [[ "${OS_VERSION}" = *"CentOS release 6."* ]] || [[ "${OS_VERSION}" = *"CentOS Linux release 7."* ]]; then
+if [[ ${RHVER} -eq 7 ]]; then
     JOB_CMAKE='cmake3'
-    CMAKE_OPTS+=" -DWITH_LIBEVENT=bundled"
-fi
-
-if [[ "${OS_VERSION}" = *"Ubuntu 16.04."* ]] || [[ "${OS_VERSION}" = *"Debian GNU/Linux 9."* ]] ; then
     CMAKE_OPTS+=" -DWITH_LIBEVENT=bundled"
 fi
 
@@ -159,14 +141,9 @@ if [[ "$COMPILER" != "default" ]]; then
     export CXX=$(echo ${COMPILER} | sed -e 's/gcc/g++/; s/clang/clang++/')
 fi
 
-# CentOS 6 and 7
+# CentOS 7
 if [[ -f /opt/rh/devtoolset-8/enable ]]; then
     source /opt/rh/devtoolset-8/enable
-fi
-
-# Centos 6/i386
-if [[ $(rpm --eval %_arch) = "i386" ]] && [[ -f /opt/rh/devtoolset-2/enable ]]; then
-    source /opt/rh/devtoolset-2/enable
 fi
 
 # ------------------------------------------------------------------------------
@@ -195,17 +172,13 @@ else
     WITH_MECAB="system"
 fi
 
-if [[ "${WITH_KEYRING_VAULT}" == "ON" ]] && [[ "${OS_VERSION}" != *"CentOS release 6."* ]]; then
-    CMAKE_OPTS+=" -DWITH_KEYRING_VAULT=ON -DWITH_KEYRING_VAULT_TEST=ON"
-else
-    CMAKE_OPTS+=" -DWITH_KEYRING_VAULT=OFF -DWITH_KEYRING_VAULT_TEST=OFF"
-fi
+CMAKE_OPTS+=" -DWITH_KEYRING_VAULT=ON -DWITH_KEYRING_VAULT_TEST=ON"
 
 # ------------------------------------------------------------------------------
 # Check ZenFS
 # ------------------------------------------------------------------------------
 if [[ "${ZEN_FS_MTR}" = "yes" ]]; then
-    if [[ ${DOCKER_OS} = "ubuntu-focal" ]] || [[ ${DOCKER_OS} = "debian-bullseye" ]]; then
+    if [[ ${DOCKER_OS} = "ubuntu-jammy" ]] || [[ ${DOCKER_OS} = "debian-bullseye" ]] || [[ ${DOCKER_OS} = "oraclelinux-9" ]]; then
         CMAKE_OPTS+=" -DROCKSDB_PLUGINS=zenfs -DWITH_ZENFS_UTILITY=ON"
     fi
 fi
@@ -228,7 +201,6 @@ pushd ${WORKDIR}
         -DWITH_ICU=bundled \
         -DWITH_READLINE=system \
         -DBUILD_CONFIG=mysql_release \
-        -DFEATURE_SET=community \
         -DWITH_PAM=ON \
         -DWITH_NUMA=ON \
         -DWITH_ZLIB=bundled \
@@ -236,8 +208,6 @@ pushd ${WORKDIR}
         -DWITH_LZ4=bundled \
         -DWITH_FIDO=bundled \
         -DWITH_INNODB_MEMCACHED=ON \
-        -DENABLE_DOWNLOADS=ON \
-        -DDOWNLOAD_ROOT=${DOWNLOAD_DIR} \
         -DDOWNLOAD_BOOST=ON \
         -DWITH_BOOST=${DOWNLOAD_DIR} \
         -DCMAKE_INSTALL_PREFIX=/usr/local/$PRODUCT_FULL \

--- a/local/test-binary
+++ b/local/test-binary
@@ -28,23 +28,16 @@ ln -sf ${WORKDIR_ABS}/PS/library_output_directory ${WORKDIR_ABS}/library_output_
 cd ${WORKDIR_ABS}/PS/mysql-test
 TESTCASE_TIMEOUT=30
 PARALLEL=$(grep -c ^processor /proc/cpuinfo)
-# CentOS 6 & 7
+# CentOS 7
 if [[ -f /opt/rh/devtoolset-8/enable ]]; then
     source /opt/rh/devtoolset-8/enable
 fi
 
-# Centos 6/i386
-if [[ $(rpm --eval %_arch) = "i386" ]] && [[ -f /opt/rh/devtoolset-2/enable ]]; then
-    source /opt/rh/devtoolset-2/enable
-fi
-
-OPENSSL_HEADER="/usr/include/openssl/opensslv.h"
 TOKUDB_PLUGIN=$(find $WORKDIR_ABS/PS/plugin_output_directory -type f -name 'ha_tokudb.so')
 HOTBACKUP_LIB=$(find $WORKDIR_ABS/PS -type f -name 'libHotBackup.so')
 HOTBACKUP_PLUGIN=$(find $WORKDIR_ABS/PS/plugin_output_directory -type f -name 'tokudb_backup.so')
 JEMALLOC=$(find /lib* /usr/lib* /usr/local/lib* -type f -name 'libjemalloc.so*' | head -n1)
 EATMYDATA=$(find /lib* /usr/lib* /usr/local/lib* -type f -name '*eatmyda*.so*' | head -n1)
-OPENSSL_VER=$(grep -o 'define SHLIB_VERSION_NUMBER .*$' ${OPENSSL_HEADER} | awk -F'"' '{print $(NF-1)}' | sed -e 's:[a-z]::g')
 
 #
 if [[ -z "${EATMYDATA}" ]]; then
@@ -59,10 +52,10 @@ if [[ -z "${JEMALLOC}" ]]; then
 fi
 #
 MTR_ARGS+=" --timestamp --report-unstable-tests"
+ANALYZER_MTR_ARGS=""
 #
 if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
-  MTR_ARGS+=" --valgrind --valgrind-clients --valgrind-option=--leak-check=full --valgrind-option=--show-leak-kinds=all"
-  [[ ${OPENSSL_VER} < '1.0.2' ]] && export OPENSSL_ia32cap=~0x200000000000000
+  ANALYZER_MTR_ARGS+=" --valgrind --valgrind-clients --valgrind-option=--leak-check=full --valgrind-option=--show-leak-kinds=all"
   TESTCASE_TIMEOUT=$((TESTCASE_TIMEOUT * 2))
   if [[ ${PARALLEL} -gt 1 ]]; then
     PARALLEL=$((PARALLEL/3))
@@ -70,8 +63,10 @@ if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
 fi
 
 if [[ "${ANALYZER_OPTS}" == *WITH_*SAN*=ON* ]]; then
-    MTR_ARGS+=" --sanitize"
+    ANALYZER_MTR_ARGS+=" --sanitize"
 fi
+
+MTR_ARGS+=${ANALYZER_MTR_ARGS}
 
 if [[ "${ANALYZER_OPTS}" == *WITH_ASAN=ON* ]]; then
   export ASAN_OPTIONS=allocator_may_return_null=true
@@ -154,6 +149,7 @@ if [[ "${TOKUDB_ENGINES_MTR}" = "yes" ]] && [[ -n "${TOKUDB_PLUGIN}" ]]; then
             --mysqld=--plugin-load=tokudb=ha_tokudb.so --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
             --mysqld=--loose-tokudb_auto_analyze=0 --mysqld=--loose-tokudb_analyze_in_background=false \
             ${TOKUDB_ENGINES_MTR_ARGS} \
+            ${ANALYZER_MTR_ARGS} \
             --junit-output=${WORKDIR_ABS}/junit_tokudb.xml \
             --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.tokudb" || true
 fi
@@ -187,12 +183,13 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
         --tmpdir="/tmp/ps_mtr_tempdir" \
         --vardir="/tmp/ci_disk_dir" \
         ${CI_TESTS} \
+        ${ANALYZER_MTR_ARGS} \
         --junit-output=${WORKDIR_ABS}/junit_ci_fs.xml \
         --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.ci_fs" || true
 fi
 
 if [[ ${ZEN_FS_MTR} = 'yes' ]] && [[ ${WITH_ROCKSDB} = 'ON' ]]; then
-    if [[ ${DOCKER_OS} = 'ubuntu-focal' ]] || [[ ${DOCKER_OS} = 'debian-bullseye' ]]; then
+    if [[ ${DOCKER_OS} = 'ubuntu-jammy' ]] || [[ ${DOCKER_OS} = 'debian-bullseye' ]] || [[ ${DOCKER_OS} = 'oraclelinux-9' ]]; then
         sudo install --owner=root --group=root --mode=+rx ${WORKDIR_ABS}/PS/runtime_output_directory/zenfs /usr/bin/
 
         sudo rm -rf /tmp/zenfs* || true
@@ -229,12 +226,13 @@ if [[ ${ZEN_FS_MTR} = 'yes' ]] && [[ ${WITH_ROCKSDB} = 'ON' ]]; then
             --parallel=3 \
             --suite=rocksdb \
             ${ROCKSDB_ZENFS_MTR_ARGS} \
+            ${ANALYZER_MTR_ARGS} \
             --junit-output=${WORKDIR_ABS}/junit_rocksdb_zenfs.xml \
             --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.rocksdb_zenfs" || true
     fi
 fi
 
-if [[ ${KEYRING_VAULT_MTR} == 'yes' ]] && [[ ${DOCKER_OS} != 'centos-6' ]] && [[ ${DOCKER_OS} != 'i386/centos-6' ]]; then
+if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
     if [ -f /usr/bin/yum ]; then
         if [[ -f /opt/rh/httpd24/enable ]]; then
             source /opt/rh/httpd24/enable
@@ -254,6 +252,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]] && [[ ${DOCKER_OS} != 'centos-6' ]] && [[
         --big-test \
         --unit-tests \
         --suite=keyring_vault \
+        ${ANALYZER_MTR_ARGS} \
         --junit-output=${WORKDIR_ABS}/junit_keyring_vault_dev_v1.xml \
         --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_dev_v1" || true
 
@@ -269,6 +268,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]] && [[ ${DOCKER_OS} != 'centos-6' ]] && [[
         --big-test \
         --unit-tests \
         --suite=keyring_vault \
+        ${ANALYZER_MTR_ARGS} \
         --junit-output=${WORKDIR_ABS}/junit_keyring_vault_dev_v2.xml \
         --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_dev_v2" || true
 
@@ -286,6 +286,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]] && [[ ${DOCKER_OS} != 'centos-6' ]] && [[
         --big-test \
         --unit-tests \
         --suite=keyring_vault \
+        ${ANALYZER_MTR_ARGS} \
         --junit-output=${WORKDIR_ABS}/junit_keyring_vault_prod_v1.xml \
         --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_prod_v1" || true
 
@@ -302,6 +303,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]] && [[ ${DOCKER_OS} != 'centos-6' ]] && [[
         --big-test \
         --unit-tests \
         --suite=keyring_vault \
+        ${ANALYZER_MTR_ARGS} \
         --junit-output=${WORKDIR_ABS}/junit_keyring_vault_prod_v2.xml \
         --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_prod_v2" || true
 fi


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7

Completely removed CentOS 6 / RHEL 6 logic from the scripts.

ZenFS prerequisites ('libgglags-dedel' and 'util-linux') are now also installed on Oracle Linux 9.

Removed 're2' packages from the dependency lists as they are no longer needed for 8.0.

Pre-downloaded version of the 'Boost' library updated to '1.77.0'.

ZenFS is now supported on the following platforms:
- 'ubuntu:jammy'
- 'debian:bullseye'
- 'oraclelinux:9' We also run these docker images on 'docker-32gb-bullseye' AMI instead of 'docker-32gb'.

'ASan' and 'Valgrind' param jobs now use 'ubuntu:jammy' image as it has the most recent tools.

The 'build-binary' script no longer requires 'lsb_release' utility.

Fixed problem with the 'test-binary' script where
Sanitizer / Valgrind MTR options were passed to the main MTR run only.

Both 'install-deps' and 'build-binary' scripts now download '.tar.bz2'
Boost library archive instead of '.tar.gz'.