### PR TITLE
PS-7 fix: Updated git to version 2.x.x on CentOS 7

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -37,6 +37,17 @@ if [ -f /usr/bin/yum ]; then
     sleep 1
   done
 
+  if [[ ${RHVER} -eq 7 ]]; then
+      # installing EndPoint repo to get 'git' 2.x.x package
+      until yum -y install ${PKGLIST} ; do
+        echo "waiting"
+        sleep 1
+      done
+      wget_loop 'endpoint-repo.x86_64.rpm' 'https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm'
+      yum -y install ${DOWNLOAD_ROOT}/endpoint-repo.x86_64.rpm
+      rm -f ${DOWNLOAD_ROOT}/endpoint-repo.x86_64.rpm
+  fi
+
   if [[ ${RHVER} -eq 8 ]]; then
       PKGLIST+=" dnf-utils"
       until yum -y install ${PKGLIST} ; do


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7

On CentOS 7 we now install 'git' package version '2.x.x' (instead of standard '1.8.x') from the custom 'EndPoint' repo
(https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm).

This helps to avoid problems with extracting RocksDB version tags on this platform.