### PR TITLE
PXC-4213: Make possible to disable tests executed in ci_fs

### DIFF
--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -288,14 +288,23 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
         MTR_ARGS_CI+=" --big-test"
     fi
 
-    CI_TESTS=""
-    for CI_TESTS_TMP in $(grep --exclude="*.inc" --exclude="*.log" -rl . -e include/have_case_insensitive_file_system.inc | awk -F '/' '{print $NF}' | sed 's/.test//g'); do
-        CI_TESTS+=" $CI_TESTS_TMP"
-    done
+    # Collect all CI_FS tests
+    CI_TESTS=$(grep --exclude="*.inc" --exclude="*.log" -rl . -e include/have_case_insensitive_file_system.inc | awk -F '/' '{print $(NF-2)"."$NF}' | sed 's/\.test//g' | sed 's/^\./main/g')
     # Requested in PS-7602
     if [[ ${CMAKE_BUILD_TYPE} = 'Debug' ]]; then
         CI_TESTS+=" information_schema.i_s_schema_definition_debug"
     fi
+
+    # Filter out disabled tests
+    # Skip lines starting with #
+    # Grab until whitespace or :
+    DISABLED_TESTS=$(grep -P -o collections/disabled.def -e'^\s*[^#][^:\s]*')
+
+    set +x
+    for CURRENT_TEST in $DISABLED_TESTS; do
+        CI_TESTS=${CI_TESTS//"$CURRENT_TEST"/""}
+    done
+    set -x
 
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --result-file \


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4213

Problem:
If CI_FS test is disabled in disabled.def, it is executed anyway

Cause:
We search for CI_FS tests and explicitly specify the list to be executed by mtr framework. This cause disabled.def exclusions to be skipped.

Solution:
Filter out tests disabled by disabled.def file