### PR TITLE
PS-7 ps57.cd: use hashicorp/consul instead of consul

### DIFF
--- a/local/bootstrap-vault
+++ b/local/bootstrap-vault
@@ -40,7 +40,7 @@ parse_arguments() {
 
 function prepare_consul {
     docker rm -f consul ||:
-    docker run -d --name=consul --hostname=consul --net bridge-vault -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' consul agent -server -bind=0.0.0.0 -client=0.0.0.0 -alt-domain=consul -retry-join=127.0.0.1 -bootstrap-expect=1
+    docker run -d --name=consul --hostname=consul --net bridge-vault -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' hashicorp/consul agent -server -bind=0.0.0.0 -client=0.0.0.0 -alt-domain=consul -retry-join=127.0.0.1 -bootstrap-expect=1
     return
 }
 


### PR DESCRIPTION
According to https://hub.docker.com/_/consul:
Starting with Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from hashicorp/consul instead of consul.

(cherry picked from commit 10305daace235fcadb58f77419cd7811659ee6bb)