### PR TITLE
PS-8978: Add missing router unit tests

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -233,7 +233,10 @@ fi
 if [ -d ${SOURCEDIR}/rqg ]; then
     cp -r ${SOURCEDIR}/rqg ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 fi
-cp -r ${WORKDIR}/unittest/gunit/*  ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+# Copy unit tests
+cp ${WORKDIR}/CTestTestfile.cmake ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+cp -r ${WORKDIR}/unittest ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/runtime_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/library_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/plugin_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/

--- a/local/test-binary
+++ b/local/test-binary
@@ -20,7 +20,8 @@ rm -fr ${WORKDIR_ABS}/PS
 mkdir -p ${WORKDIR_ABS}/PS/sql
 tar -C ${WORKDIR_ABS}/PS --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz | head -1)
 
-mkdir -p ${WORKDIR_ABS}/unittest && ln -sf ${WORKDIR_ABS}/PS ${WORKDIR_ABS}/unittest/gunit
+ln -sf ${WORKDIR_ABS}/PS/router ${WORKDIR_ABS}/router
+ln -sf ${WORKDIR_ABS}/PS/unittest ${WORKDIR_ABS}/unittest
 ln -sf ${WORKDIR_ABS}/PS/runtime_output_directory ${WORKDIR_ABS}/runtime_output_directory
 ln -sf ${WORKDIR_ABS}/PS/plugin_output_directory ${WORKDIR_ABS}/plugin_output_directory
 ln -sf ${WORKDIR_ABS}/PS/library_output_directory ${WORKDIR_ABS}/library_output_directory

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -29,7 +29,8 @@ rm -fr ${WORKDIR_ABS}/PS
 mkdir -p ${WORKDIR_ABS}/PS/sql
 tar -C ${WORKDIR_ABS}/PS --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz | head -1)
 
-mkdir -p ${WORKDIR_ABS}/unittest && ln -sf ${WORKDIR_ABS}/PS ${WORKDIR_ABS}/unittest/gunit
+ln -sf ${WORKDIR_ABS}/PS/router ${WORKDIR_ABS}/router
+ln -sf ${WORKDIR_ABS}/PS/unittest ${WORKDIR_ABS}/unittest
 ln -sf ${WORKDIR_ABS}/PS/runtime_output_directory ${WORKDIR_ABS}/runtime_output_directory
 ln -sf ${WORKDIR_ABS}/PS/plugin_output_directory ${WORKDIR_ABS}/plugin_output_directory
 ln -sf ${WORKDIR_ABS}/PS/library_output_directory ${WORKDIR_ABS}/library_output_directory


### PR DESCRIPTION
Router unit tests were not copied to `.tar.gz` archive.