### PR TITLE
PS-8978: Add option to run MySQL Router unit tests

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -34,6 +34,7 @@ docker run --rm \
     export DIST_NAME='${DIST_NAME}'
     export SSL_VER='${SSL_VER}'
     export ZEN_FS_MTR='${ZEN_FS_MTR}'
+    export UNIT_TESTS_ROUTER='${UNIT_TESTS_ROUTER}'
     export DOCKER_OS='${DOCKER_OS//:/-}'
 
     mkdir  /tmp/results

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -101,6 +101,12 @@
         - "no"
         - "yes"
         description: Run ZenFS MTR tests
+    - choice:
+        name: UNIT_TESTS_ROUTER
+        choices:
+        - "no"
+        - "yes"
+        description: Run MySQL Router unit tests
     - string:
         name: MTR_ARGS
         default: --unit-tests-report --mem --big-test

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -565,6 +565,10 @@ pipeline {
             choices: 'yes\nno',
             description: 'Run case-insensetive MTR tests',
             name: 'CI_FS_MTR')
+        choice(
+            choices: 'no\nyes',
+            description: 'Run MySQL Router unit tests',
+            name: 'UNIT_TESTS_ROUTER')
         string(
             defaultValue: '--unit-tests-report --mem --big-test',
             description: 'mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report',

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -116,6 +116,12 @@
         - "no"
         - "yes"
         description: Run ZenFS MTR tests
+    - choice:
+        name: UNIT_TESTS_ROUTER
+        choices:
+        - "no"
+        - "yes"
+        description: Run MySQL Router unit tests
     - string:
         name: MTR_ARGS
         default: --unit-tests-report --mem --big-test

--- a/local/build-binary
+++ b/local/build-binary
@@ -235,8 +235,10 @@ if [ -d ${SOURCEDIR}/rqg ]; then
 fi
 # Copy unit tests
 cp ${WORKDIR}/CTestTestfile.cmake ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
-cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/unittest ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+if [[ "${UNIT_TESTS_ROUTER}" = "yes" ]]; then
+    cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+fi
 cp -r ${WORKDIR}/runtime_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/library_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/plugin_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/


### PR DESCRIPTION
Add `UNIT_TESTS_ROUTER` option (off by default) to decide whether MySQL Router unit tests should be run