### PR TITLE
PS-8978: Improve `percona-server-8.0-pipeline-parallel-mtr`

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -55,8 +55,8 @@ if [[ "${KEYRING_VAULT_MTR}" == 'yes' ]]; then
     VAULT_DOCKER_FLAG="--network bridge-vault"
 fi
 
-docker run --rm --shm-size=24G \
-    --tmpfs /dev/shm:rw,exec,size=24G \
+docker run --rm --shm-size=32G \
+    --tmpfs /dev/shm:rw,exec,size=32G \
     --security-opt seccomp=unconfined \
     --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
     --mount type=bind,source=${ROOT_DIR},destination=/tmp/ps \

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -92,7 +92,7 @@ void doTests(String WORKER_ID, String SUITES, String STANDALONE_TESTS = '', bool
                     echo "Preparing filesystem for CIFS tests"
 
                     if [ -f /usr/bin/yum ]; then
-                        sudo yum -y dosfstools
+                        sudo yum -y install dosfstools
                     else
                         sudo apt-get install -y dosfstools
                     fi

--- a/jenkins/suites-groups.sh
+++ b/jenkins/suites-groups.sh
@@ -19,14 +19,14 @@
 #    and another executes only bit tests.
 
 # Unit tests will be executed by worker 1
-WORKER_1_MTR_SUITES="main|nobig,binlog_nogtid,innodb_undo,test_services,service_sys_var_registration,connection_control,service_status_var_registration,service_udf_registration,interactive_utilities"
-WORKER_2_MTR_SUITES="main|big"
-WORKER_3_MTR_SUITES="innodb"
-WORKER_4_MTR_SUITES="auth_sec,audit_log,audit_log_filter,binlog_57_decryption,percona-pam-for-mysql,data_masking,component_masking_functions,procfs,rpl_encryption,audit_null,engines/iuds,engines/funcs,group_replication,jp,stress"
-WORKER_5_MTR_SUITES="rpl,rpl_gtid,rpl_nogtid,binlog,sys_vars,funcs_2,opt_trace,json,collations"
-WORKER_6_MTR_SUITES="innodb_gis,perfschema,parts,clone,query_rewrite_plugins,funcs_1"
-WORKER_7_MTR_SUITES="rocksdb,rocksdb_stress,rocksdb_rpl,innodb_zip,information_schema,rocksdb_sys_vars"
-WORKER_8_MTR_SUITES="component_keyring_file,innodb_fts,x,encryption,sysschema,binlog_gtid,gcol,federated,test_service_sql_api,gis,secondary_engine"
+WORKER_1_MTR_SUITES="sys_vars,sysschema,innodb_zip,gcol,encryption,engines/iuds,funcs_1,funcs_2,opt_trace,json,collations,query_rewrite_plugins,information_schema,federated,test_service_sql_api,gis,secondary_engine,test_services,service_sys_var_registration,connection_control,service_status_var_registration,service_udf_registration,interactive_utilities,audit_log,percona-pam-for-mysql,data_masking,component_masking_functions,procfs,rpl_encryption,audit_null,jp,stress"
+WORKER_2_MTR_SUITES="innodb_undo,innodb_fts,perfschema,component_keyring_file,x,auth_sec,audit_log_filter,binlog,binlog_gtid,binlog_nogtid,binlog_57_decryption"
+WORKER_3_MTR_SUITES="rpl,rpl_gtid"
+WORKER_4_MTR_SUITES="group_replication"
+WORKER_5_MTR_SUITES="rocksdb,rocksdb_stress,rocksdb_rpl,rocksdb_sys_vars,clone"
+WORKER_6_MTR_SUITES="innodb"
+WORKER_7_MTR_SUITES="main|nobig,innodb_gis,engines/funcs"
+WORKER_8_MTR_SUITES="main|big,rpl_nogtid,parts"
 
 INPUT=${2:-./mysql-test-run.pl}
 

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -87,9 +87,9 @@ if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
 fi
 
 # hack for too big instances ;)
-if [[ ${PARALLEL} -gt 8 ]]; then
-  echo "Limit parallel ${PARALLEL} -> 8"
-  PARALLEL=8
+if [[ ${PARALLEL} -gt 10 ]]; then
+  echo "Limit parallel ${PARALLEL} -> 10"
+  PARALLEL=10
 fi
 
 if [[ "${ANALYZER_OPTS}" == *WITH_*SAN*=ON* ]]; then

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -182,92 +182,105 @@ for suite in "${ARRAY_MTR_SUITES[@]}"; do
         big_tests_this=0
     fi
 
-    suiteNoSlash=${suite//"/"/"_"}
-    echo "Running MTR suite: $suite (noslash: $suiteNoSlash)"
-
-    start=`date +%s`
-
     if [[ $only_big_tests_this == "0" ]]; then
-        echo "Executing normal tests for suite $suite"
-
-        df -h
-        du /dev/shm
-        mount
-        ls -la /dev/shm
-        cat /proc/meminfo
-
-        MTR_ARGS_NORMAL=${MTR_ARGS}
-
-        if [[ $UNIT_TESTS == "1" ]]; then
-            MTR_ARGS_NORMAL+=" --unit-tests-report"
-            UNIT_TESTS=0
-        fi
-
-        MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-            --parallel=${PARALLEL} \
-            --result-file \
-            --suite=$suite \
-            --suite-timeout=9999 \
-            --testcase-timeout=${TESTCASE_TIMEOUT} \
-            ${MTR_ARGS_NORMAL} \
-            --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
-            --max-test-fail=0 \
-            --junit-output=${WORKDIR_ABS}/junit_${suiteNoSlash}.xml \
-            --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
-
-        ln -s $PWD/var $PWD/var_${suiteNoSlash}
-        which rsync
-        rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${suiteNoSlash} $PWD/mtr_var
-
-        killall -9 mysqld || true
-        rm -rf $PWD/var_${suiteNoSlash}
-
-        df -h
-        du -sh /dev/shm
+        suitesNormal+="$suite,"
     fi
-    end=`date +%s`
-    runtime=$((end-start))
-    echo KH,SUITE_NO_BIG,${suite},time,$runtime
 
     if [[ $big_tests_this == "1" ]]; then
-        echo "Executing big tests for suite $suite"
-        MTR_ARGS_BIG=${MTR_ARGS}
-        MTR_ARGS_BIG+=" --only-big-test"
-        suiteNoSlash+="_bigtest"
-        TESTCASE_TIMEOUT_BIG=$((TESTCASE_TIMEOUT * 2))
-
-        if [[ $UNIT_TESTS == "1" ]]; then
-            MTR_ARGS_BIG+=" --unit-tests-report"
-            UNIT_TESTS=0
-        fi
-
-        MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-            --parallel=${PARALLEL} \
-            --result-file \
-            --suite=$suite \
-            --suite-timeout=9999 \
-            --testcase-timeout=${TESTCASE_TIMEOUT} \
-            ${MTR_ARGS_BIG} \
-            --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
-            --max-test-fail=0 \
-            --junit-output=${WORKDIR_ABS}/junit_${suiteNoSlash}.xml \
-            --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
-
-        ln -s $PWD/var $PWD/var_${suiteNoSlash}
-        rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${suiteNoSlash} $PWD/mtr_var
-
-        killall -9 mysqld || true
-        rm -rf $PWD/var_${suiteNoSlash}
-
-        df -h
-        du -sh /dev/shm
+        suitesBig+="$suite,"
     fi
+done
+
+echo "Running MTR normal suites: $suitesNormal"
+echo "Running MTR big suites: $suitesBig"
+
+start=`date +%s`
+
+if [[ "$suitesNormal" != "" ]]; then
+    suitesNormal=${suitesNormal::-1};
+    suiteNoSlash="WORKER_${WORKER_NO}"
+    echo "Executing normal tests for suites $suitesNormal"
+
+    df -h
+    du /dev/shm
+    mount
+    ls -la /dev/shm
+    cat /proc/meminfo
+
+    MTR_ARGS_NORMAL=${MTR_ARGS}
+
+    if [[ $UNIT_TESTS == "1" ]]; then
+        MTR_ARGS_NORMAL+=" --unit-tests-report"
+        UNIT_TESTS=0
+    fi
+
+    MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+        --parallel=${PARALLEL} \
+        --result-file \
+        --suite=$suitesNormal \
+        --suite-timeout=9999 \
+        --testcase-timeout=${TESTCASE_TIMEOUT} \
+        ${MTR_ARGS_NORMAL} \
+        --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
+        --max-test-fail=0 \
+        --junit-output=${WORKDIR_ABS}/junit_${suiteNoSlash}.xml \
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
+
+    ln -s $PWD/var $PWD/var_${suiteNoSlash}
+    which rsync
+    rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${suiteNoSlash} $PWD/mtr_var
+
+    killall -9 mysqld || true
+    rm -rf $PWD/var_${suiteNoSlash}
+
+    df -h
+    du -sh /dev/shm
 
     end=`date +%s`
     runtime=$((end-start))
-    echo KH,SUITE_TOTAL,${suite},time,$runtime
+    echo KH,SUITE_NO_BIG,${suitesNormal},time,$runtime
+fi
 
-done
+if [[ "$suitesBig" != "" ]]; then
+    suitesBig=${suitesBig::-1};
+    suiteNoSlash="WORKER_${WORKER_NO}"
+    echo "Executing big tests for suites $suitesBig"
+
+    MTR_ARGS_BIG=${MTR_ARGS}
+    MTR_ARGS_BIG+=" --only-big-test"
+    suiteNoSlash+="_bigtest"
+    TESTCASE_TIMEOUT_BIG=$((TESTCASE_TIMEOUT * 2))
+
+    if [[ $UNIT_TESTS == "1" ]]; then
+        MTR_ARGS_BIG+=" --unit-tests-report"
+        UNIT_TESTS=0
+    fi
+
+    MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+        --parallel=${PARALLEL} \
+        --result-file \
+        --suite=$suitesBig \
+        --suite-timeout=9999 \
+        --testcase-timeout=${TESTCASE_TIMEOUT} \
+        ${MTR_ARGS_BIG} \
+        --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
+        --max-test-fail=0 \
+        --junit-output=${WORKDIR_ABS}/junit_${suiteNoSlash}.xml \
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
+
+    ln -s $PWD/var $PWD/var_${suiteNoSlash}
+    rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${suiteNoSlash} $PWD/mtr_var
+
+    killall -9 mysqld || true
+    rm -rf $PWD/var_${suiteNoSlash}
+
+    df -h
+    du -sh /dev/shm
+
+    end=`date +%s`
+    runtime=$((end-start))
+    echo KH,SUITE_TOTAL,${suitesBig},time,$runtime
+fi
 # <<<< main MTR execution loop ends here
 
 #


### PR DESCRIPTION
1. Fix missing `install` in `sudo yum -y dosfstools`
2. Set `--shm-size=32G`
3. Limit parallel to 10 threads instead of 8 (it reduces total run time from 11h to 10h)
4. Update `suites-groups.sh`
5. Test all normal suites together and all big suites together instead testing one by one (it reduces total run time from 10h to 9h)