### PR TITLE
PS-8978: Enable testing of router unit tests in Jenkins

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -34,7 +34,6 @@ docker run --rm \
     export DIST_NAME='${DIST_NAME}'
     export SSL_VER='${SSL_VER}'
     export ZEN_FS_MTR='${ZEN_FS_MTR}'
-    export UNIT_TESTS_ROUTER='${UNIT_TESTS_ROUTER}'
     export DOCKER_OS='${DOCKER_OS//:/-}'
 
     mkdir  /tmp/results

--- a/docker/run-test
+++ b/docker/run-test
@@ -99,7 +99,7 @@ docker run --rm \
     mv /tmp/ps/*.pem /tmp/results || true
     cp /tmp/ps/results/*.tar.gz /tmp/results
 
-    bash -x /tmp/scripts/test-binary /tmp/results
+    bash -x /tmp/scripts/test-binary /tmp/results /tmp/ps
 
     sudo mv /tmp/results/*.xml /tmp/ps/results/
     sudo chown $(id -u):$(id -g) /tmp/ps/results/*.xml

--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -100,7 +100,7 @@ docker run --rm --shm-size=32G \
     mv /tmp/ps/*.pem /tmp/results || true
     cp /tmp/ps/results/*.tar.gz /tmp/results
 
-    bash -x /tmp/scripts/test-binary-parallel-mtr /tmp/results
+    bash -x /tmp/scripts/test-binary-parallel-mtr /tmp/results /tmp/ps
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PS/mysql-test/mtr_var /tmp/results/log

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -101,12 +101,6 @@
         - "no"
         - "yes"
         description: Run ZenFS MTR tests
-    - choice:
-        name: UNIT_TESTS_ROUTER
-        choices:
-        - "no"
-        - "yes"
-        description: Run MySQL Router unit tests
     - string:
         name: MTR_ARGS
         default: --unit-tests-report --mem --big-test

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -565,10 +565,6 @@ pipeline {
             choices: 'yes\nno',
             description: 'Run case-insensetive MTR tests',
             name: 'CI_FS_MTR')
-        choice(
-            choices: 'no\nyes',
-            description: 'Run MySQL Router unit tests',
-            name: 'UNIT_TESTS_ROUTER')
         string(
             defaultValue: '--unit-tests-report --mem --big-test',
             description: 'mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report',

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -116,12 +116,6 @@
         - "no"
         - "yes"
         description: Run ZenFS MTR tests
-    - choice:
-        name: UNIT_TESTS_ROUTER
-        choices:
-        - "no"
-        - "yes"
-        description: Run MySQL Router unit tests
     - string:
         name: MTR_ARGS
         default: --unit-tests-report --mem --big-test

--- a/local/build-binary
+++ b/local/build-binary
@@ -235,10 +235,8 @@ if [ -d ${SOURCEDIR}/rqg ]; then
 fi
 # Copy unit tests
 cp ${WORKDIR}/CTestTestfile.cmake ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/unittest ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
-if [[ "${UNIT_TESTS_ROUTER}" = "yes" ]]; then
-    cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
-fi
 cp -r ${WORKDIR}/runtime_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/library_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/plugin_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/

--- a/local/build-binary
+++ b/local/build-binary
@@ -25,7 +25,7 @@ TAG=${TAG:-}
 DIST_NAME=${DIST_NAME:-}
 SSL_VER=${SSL_VER:-}
 TARGET_CFLAGS=${TARGET_CFLAGS:-}
-
+UNIT_TESTS_ROUTER=${UNIT_TESTS_ROUTER:-yes}
 
 # ------------------------------------------------------------------------------
 # set working dir
@@ -235,8 +235,11 @@ if [ -d ${SOURCEDIR}/rqg ]; then
 fi
 # Copy unit tests
 cp ${WORKDIR}/CTestTestfile.cmake ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
-cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/unittest ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+if [[ "${UNIT_TESTS_ROUTER}" = "yes" ]]; then
+    cp -r ${WORKDIR}/router ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
+    cp -r ${SOURCEDIR}/router/tests/component/data ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/router/tests/component/
+fi
 cp -r ${WORKDIR}/runtime_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/library_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/
 cp -r ${WORKDIR}/plugin_output_directory ${INSTALL_DIR}/usr/local/${PRODUCT_FULL}/

--- a/local/test-binary
+++ b/local/test-binary
@@ -16,9 +16,23 @@ set -o errexit
 set -o xtrace
 
 WORKDIR_ABS=$(cd ${1:-./build}; pwd -P)
+SOURCEDIR=$2
 rm -fr ${WORKDIR_ABS}/PS
 mkdir -p ${WORKDIR_ABS}/PS/sql
 tar -C ${WORKDIR_ABS}/PS --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz | head -1)
+
+if [[ "${SOURCEDIR}" != "" ]]; then
+    # Router unit tests have hard coded paths to SOURCEDIR.
+    # We link proper paths in case SOURCEDIR is not available (e.g. Jenkins docker builds).
+    if ! [ -d ${SOURCEDIR}/router/tests/component/data ]; then
+        sudo mkdir -p ${SOURCEDIR}/router/tests/component
+        sudo ln -sf ${WORKDIR_ABS}/PS/router/tests/component/data ${SOURCEDIR}/router/tests/component
+    fi
+    if ! [ -d ${SOURCEDIR}/mysql-test/std_data ]; then
+        sudo mkdir -p ${SOURCEDIR}/mysql-test
+        sudo ln -sf ${WORKDIR_ABS}/PS/mysql-test/std_data ${SOURCEDIR}/mysql-test
+    fi
+fi
 
 ln -sf ${WORKDIR_ABS}/PS/router ${WORKDIR_ABS}/router
 ln -sf ${WORKDIR_ABS}/PS/unittest ${WORKDIR_ABS}/unittest

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -25,9 +25,23 @@ ulimit -a
 echo "*******************************************************"
 
 WORKDIR_ABS=$(cd ${1:-./build}; pwd -P)
+SOURCEDIR=$2
 rm -fr ${WORKDIR_ABS}/PS
 mkdir -p ${WORKDIR_ABS}/PS/sql
 tar -C ${WORKDIR_ABS}/PS --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz | head -1)
+
+if [[ "${SOURCEDIR}" != "" ]]; then
+    # Router unit tests have hard coded paths to SOURCEDIR.
+    # We link proper paths in case SOURCEDIR is not available (e.g. Jenkins docker builds).
+    if ! [ -d ${SOURCEDIR}/router/tests/component/data ]; then
+        sudo mkdir -p ${SOURCEDIR}/router/tests/component
+        sudo ln -sf ${WORKDIR_ABS}/PS/router/tests/component/data ${SOURCEDIR}/router/tests/component
+    fi
+    if ! [ -d ${SOURCEDIR}/mysql-test/std_data ]; then
+        sudo mkdir -p ${SOURCEDIR}/mysql-test
+        sudo ln -sf ${WORKDIR_ABS}/PS/mysql-test/std_data ${SOURCEDIR}/mysql-test
+    fi
+fi
 
 ln -sf ${WORKDIR_ABS}/PS/router ${WORKDIR_ABS}/router
 ln -sf ${WORKDIR_ABS}/PS/unittest ${WORKDIR_ABS}/unittest


### PR DESCRIPTION
1. Copy missing `router/tests/component/data` files to tar.gz archive.
2. Router unit tests have hard coded paths to SOURCEDIR. We link proper paths in case SOURCEDIR is not available (e.g. Jenkins docker builds).
3. Remove `UNIT_TESTS_ROUTER` parameter from pipelines.