### PR TITLE
PS-8979: Use gcc-10 on ubuntu:focal for PS 8.2 builds

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -223,6 +223,11 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" libgsasl7"
     fi
 
+    # PS 8.2 requires gcc-10 on focal
+    if [[ ${DIST} == "focal" ]]; then
+        PKGLIST+=" gcc-10 g++-10"
+    fi
+
     # PS-7834: 8.0.26 requires GCC 8 on bionic
     if [[ ${DIST} == "bionic" ]]; then
         PKGLIST+=" gcc-8 g++-8"


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8979