### PR TITLE
ENG-1225 Revert repo parameter type to STRING

### DIFF
--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -15,11 +15,9 @@
         artifact-days-to-keep: -1
         artifact-num-to-keep: 10
     parameters:
-    - choice:
+    - string:
         name: GIT_REPO
-        choices:
-        - "https://github.com/percona/percona-server"
-        - "https://github.com/percona/mysql-5.7-post-eol"
+        default: "https://github.com/percona/percona-server"
         description: URL to percona-server repository
     - string:
         name: BRANCH

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -4,10 +4,11 @@ if (params.MTR_ARGS.contains('--big-test')) {
 
 pipeline {
     parameters {
-        choice(
-            choices: 'https://github.com/percona/percona-server\nhttps://github.com/percona/mysql-5.7-post-eol',
+        string(
+            defaultValue: 'https://github.com/percona/percona-server',
             description: 'URL to percona-server repository',
-            name: 'GIT_REPO')
+            name: 'GIT_REPO',
+            trim: true)
         string(
             defaultValue: '5.7',
             description: 'Tag/Branch for percona-server repository',

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -14,11 +14,9 @@
       lightweight-checkout: true
       script-path: jenkins/pipeline.groovy
     parameters:
-    - choice:
+    - string:
         name: GIT_REPO
-        choices:
-        - "https://github.com/percona/percona-server"
-        - "https://github.com/percona/mysql-5.7-post-eol"
+        default: "https://github.com/percona/percona-server"
         description: URL to percona-server repository
     - string:
         name: BRANCH


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/ENG-1225

Reverts the GIT_REPO jenkins job parameter type from choice to string thus enabling the job to be triggered for forks of both percona-server and mysql community.