### PR TITLE
ENG-1243 fix ps docker builds

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -158,6 +158,8 @@ if [ -f /usr/bin/yum ]; then
         done
     elif [[ ${RHVER} -eq 8 ]]; then
         yum -y install centos-release-stream
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
         until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12}; do
             echo "waiting"
             sleep 1

--- a/docker/prepare-docker
+++ b/docker/prepare-docker
@@ -12,6 +12,7 @@ build_docker() {
         ${DOCKER_DIR}/Dockerfile.inc \
         > ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-}
 
+    export DOCKER_BUILDKIT=0
     docker build \
         --squash \
         --no-cache \


### PR DESCRIPTION
1. fix build for outdated, but used Centos8
2. don't use BuildKit for docker images creation

(cherry picked from commit 67a5862d22b3fbbf112e73e211ffdbe4b0113b11)