### PR TITLE
PS-9328: Merge 8.4.2 - Ensure that PATH env variable is set when runn…

### DIFF
--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -169,7 +169,7 @@ if [[ $UNIT_TESTS == "1" ]]; then
     fi
 
     pushd ${BUILD_DIR}/mysql-test
-    env -i "${MTR_VAULT_ARRAY[@]}" MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+    env "${MTR_VAULT_ARRAY[@]}" MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --parallel=${PARALLEL} \
         --result-file \
         --unit-tests-report \


### PR DESCRIPTION
…ing unit tests.

Do not empty environment before executing ./mysql-test-run.pl for unit tests.

This should fix routertest_router_default_paths unit test failures, as this test relies on PATH environment variable being set.