### PR TITLE
PS-9293: 8.0.39 Merge - Ensure that PATH env variable is set when running unit tests (8.0 version)

### DIFF
--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -170,7 +170,7 @@ if [[ $UNIT_TESTS == "1" ]]; then
     fi
 
     pushd ${BUILD_DIR}/mysql-test
-    env -i "${MTR_VAULT_ARRAY[@]}" MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+    env "${MTR_VAULT_ARRAY[@]}" MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --parallel=${PARALLEL} \
         --result-file \
         --unit-tests-report \


### PR DESCRIPTION
Do not empty environment before executing ./mysql-test-run.pl for unit tests.

This should fix routertest_router_default_paths unit test failures, as this test relies on PATH environment variable being set.