### PR TITLE
PKG-275 Removes Amazon linux 2 from the PS param job

### DIFF
--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -198,7 +198,6 @@
           - debian:buster
           - debian:bullseye
           - debian:bookworm
-          - amazonlinux:2
     builders:
     - trigger-builds:
       - project: percona-server-5.7-pipeline


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PKG-275

A testrun can be triggered from the pipeline job if necessary until Amazon linux is officially supported for Percona server for MySQL.