### PR TITLE
PKG-264 ps57.cd: fix ps57 pipline job

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -258,9 +258,13 @@ pipeline {
                             sh '''
                                 git reset --hard
                                 git clean -xdf
-                                rm -rf sources/results
+                                ls -la ./ || true
+                                ls -la sources/ || true
+                                ls -la sources/results/ || true
+                                rm -rf sources/results/*
                                 until aws s3 cp --no-progress s3://ps-build-cache/${BUILD_TAG}/binary.tar.gz ./sources/results/binary.tar.gz; do
                                     sleep 5
+                                    mkdir -p sources/results
                                 done
 
                                 sudo yum -y install jq


### PR DESCRIPTION
1. remove sources/results/ contents instead of entire folder
2. add ls output for further debug purposes
3. recreate sources/results/ folder on the first binary.tar.gz download failure