### PR TITLE
PS-9500: Fix issue with `git -C sources reset` and `git -C sources clean`

### DIFF
--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -69,9 +69,13 @@ void prepareWorkspace(Integer WORKER_ID) {
             sudo git reset --hard
             if [[ "${WORKER_ID}" != "1" ]]; then
                 sudo git clean -xdf
+            else
+                # sources exists only for WORKER #1 but not for retry/re-runs
+                if [[ -d sources ]]; then
+                    sudo git -C sources reset --hard
+                    sudo git -C sources clean -xdf
+                fi
             fi
-            sudo git -C sources reset --hard || :
-            sudo git -C sources clean -xdf   || :
 
             if [ -f /usr/bin/yum ]; then
                 sudo yum -y install jq gflags-devel


### PR DESCRIPTION
1. `sudo git clean -xdf` cleans all subdirectories including `sources`.
2. `sources` exists only for WORKER 1 and only during the 1st run. They don't exist for retry/re-runs.

The issue:
```
+ echo 'prepareWorkspace for MTR worker 7'
prepareWorkspace for MTR worker 7
+ sudo git reset --hard
HEAD is now at 4a6336b PKG-437 8.0 part (#443)
+ [[ 7 != \1 ]]
+ sudo git clean -xdf
+ sudo git -C sources reset --hard
fatal: cannot change to 'sources': No such file or directory
+ :
+ sudo git -C sources clean -xdf
fatal: cannot change to 'sources': No such file or directory
+ :
+ '[' -f /usr/bin/yum ']'
+ sudo yum -y install jq gflags-devel
```