### PR TITLE
PS-9500: Remove `centos:7` platform

### DIFF
--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -200,7 +200,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:7
           - centos:8
           - oraclelinux:9
           - ubuntu:focal

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -39,7 +39,6 @@
     - choice:
         name: DOCKER_OS
         choices:
-        - centos:7
         - centos:8
         - oraclelinux:9
         - ubuntu:focal


### PR DESCRIPTION
1. `centos:7` is EOL

2. It doesn't work anyways with PS 8.0.41-32:
```
In file included from /tmp/sources/sql/handler.h:55,
                 from /tmp/sources/sql/mysqld.h:67,
                 from /tmp/sources/components/masking_functions/src/masking_functions/server_helpers.cpp:20:
/tmp/sources/include/my_checksum.h: In function 'ha_checksum my_checksum(ha_checksum, const unsigned char*, size_t)':
/tmp/sources/include/my_checksum.h:126:10: error: 'crc32_z' was not declared in this scope; did you mean 'crc32'?
  126 |   return crc32_z(crc, pos, length);
      |          ^~~~~~~
      |          crc32
```