### PR TITLE
PS-9500: Install missing packages

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -121,10 +121,10 @@ if [ -f /usr/bin/yum ]; then
   fi
 
   PKGLIST=" \
-    gcc-c++ libtool gperf ncurses-devel perl readline-devel jemalloc zip unzip tar gzip \
+    rsync gcc-c++ libtool gperf ncurses-devel perl readline-devel jemalloc zip unzip tar gzip \
     time zlib-devel libaio-devel bison cmake pam-devel jemalloc-devel valgrind \
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
-    cpio perl-JSON perl-Digest perl-Digest-MD5 \
+    cpio perl-JSON perl-Digest perl-Digest-MD5 perl-XML-Parser perl-Expect perl-LWP-Protocol-https \
     numactl-devel git which make rpm-build ccache sudo libasan lz4-devel \
     libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq perl-XML-Simple libcurl-devel perl-Test-Simple \
     cyrus-sasl-devel cyrus-sasl-scram krb5-devel libudev-devel python3-pip python3-devel libevent-devel \
@@ -270,13 +270,13 @@ if [ -f /usr/bin/apt-get ]; then
     done
 
     PKGLIST=" \
-        curl bison cmake perl libssl-dev gcc g++ libaio-dev libldap2-dev libwrap0-dev gdb zip unzip gawk \
+        rsync curl bison cmake perl libssl-dev gcc g++ libaio-dev libldap2-dev libwrap0-dev gdb zip unzip gawk \
         libmecab-dev libncurses5-dev libreadline-dev libpam-dev zlib1g-dev libcurl4-openssl-dev \
-        libnuma-dev libjemalloc-dev libc6-dbg valgrind libjson-perl libevent-dev pkg-config \
+        libnuma-dev libjemalloc-dev libc6-dbg valgrind libjson-perl libexpect-perl libevent-dev pkg-config \
         libmecab2 mecab mecab-ipadic git autoconf libsasl2-dev libsasl2-modules devscripts \
         debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
         tzdata golang libunwind-dev zstd python3-mysqldb libdbi-perl libdbd-mysql-perl \
-        cpio jq openssl libxml-simple-perl \
+        cpio jq openssl libxml-simple-perl libxml-parser-perl \
         libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev libudev-dev libzstd-dev libsys-meminfo-perl \
         libatomic1 \
     "

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -42,23 +42,6 @@ if [[ -f /opt/rh/devtoolset-8/enable ]]; then
     source /opt/rh/devtoolset-8/enable
 fi
 
-# TODO: This should be already there in the Docker container
-if [ -f /etc/redhat-release ]; then
-    RHEL=$(rpm --eval %rhel)
-    if [ "$RHEL" == 8 ]; then
-        pushd /etc/yum.repos.d/
-        sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-        sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-        popd
-    fi
-    sudo yum install -y rsync cpanminus
-    sudo cpanm --notest Expect
-else
-    sudo apt -y update
-    sudo apt -y install rsync cpanminus
-    sudo cpanm --notest Expect
-fi
-
 JEMALLOC=$(find /lib* /usr/lib* /usr/local/lib* -type f -name 'libjemalloc.so*' | head -n1)
 EATMYDATA=$(find /lib* /usr/lib* /usr/local/lib* -type f -name '*eatmyda*.so*' | head -n1)
 


### PR DESCRIPTION
1. Oracle Linux 9 fails with:
```
+ sudo cpanm --notest Expect
! Finding Expect on cpanmetadb failed.
LWP will support https URLs if the LWP::Protocol::https module is installed.
```

2. Ubuntu Noble after `sudo ./docker/install-deps` fails with:
```
Can't locate XML/Parser.pm in @INC (you may need to install the XML::Parser module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at /mnt/storage2/ps-build-workspace/extract/mysql-test/var/10/tmpiOp5o9 line 5.
BEGIN failed--compilation aborted at /mnt/storage2/ps-build-workspace/extract/mysql-test/var/10/tmpiOp5o9 line 5.
mysqltest: At line 29: Command "perl" failed with error 2. my_errno=175.
```