### PR TITLE
PS-9598 [8.0]: Build issues with PS 9.2.0-1 on centos:8 and oraclelinux:9

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -151,6 +151,11 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ gcc-toolset-12-binutils"
         PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-annobin-annocheck gcc-toolset-12-annobin-plugin-gcc"
         PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-libatomic-devel"
+
+        # Next packages are required by 9.2.0
+        PKGLIST_DEVTOOLSET13+=" gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-binutils"
+        PKGLIST_DEVTOOLSET13+=" gcc-toolset-13-annobin-annocheck gcc-toolset-13-annobin-plugin-gcc"
+        PKGLIST_DEVTOOLSET13+=" gcc-toolset-13-libatomic-devel"
     fi
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -164,7 +169,7 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-gcc-c++ gcc-toolset-11-binutils gcc-toolset-11-annobin"
         PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-valgrind gcc-toolset-11-valgrind-devel gcc-toolset-11-libatomic-devel"
         PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-libasan-devel gcc-toolset-11-libubsan-devel"
-        PKGLIST_DEVTOOLSET10+=" gcc-toolset-11-libatomic-devel"
+        PKGLIST_DEVTOOLSET11+=" gcc-toolset-11-libatomic-devel"
     fi
 
     if [[ ${RHVER} -eq 7 ]]; then
@@ -217,13 +222,13 @@ if [ -f /usr/bin/yum ]; then
     elif [[ ${RHVER} -eq 8 ]]; then
         yum -y install centos-release-stream
         switch_to_vault_repo
-        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12}; do
+        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13}; do
             echo "waiting"
             sleep 1
         done
         yum -y remove centos-release-stream
     elif [[ ${RHVER} -eq 9 ]]; then
-        until yum -y install ${PKGLIST_DEVTOOLSET12}; do
+        until yum -y install ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13}; do
             echo "waiting"
             sleep 1
         done


### PR DESCRIPTION
```
-- Running cmake version 3.26.5
-- Found Git: /usr/bin/git (found version "2.43.5")
-- This is .el9. as found from 'rpm -qf /'
-- Looking for a devtoolset compiler
CMake Warning at CMakeLists.txt:399 (MESSAGE):
  Could not find devtoolset compiler/linker in /opt/rh/gcc-toolset-13

CMake Warning at CMakeLists.txt:401 (MESSAGE):
  You need to install the required packages:

   yum install gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-binutils gcc-toolset-13-annobin-annocheck gcc-toolset-13-annobin-plugin-gcc
```