### PR TITLE
PS-9692 [8.x]: Add `percona-server-sanitizers-epyc9654-noble.yml` pipeline

### DIFF
--- a/jenkins/jenkins-common.sh
+++ b/jenkins/jenkins-common.sh
@@ -1,0 +1,148 @@
+#!/bin/echo This script should be sourced in a shell, not executed directly
+
+# Filter valgrind logs and remove all records/stacktraces where X > 16 in:
+# ==[0-9]+== .*in loss record X of Y
+function filter_valgrind_log() {
+  local input_file="${1:-valgrind-test.log}"
+  local output_file="${2:-valgrind-test-filter.log}"
+
+  awk '
+  function strip_commas(s) {
+      gsub(",", "", s)
+      return s + 0  # force numeric
+  }
+
+  /==[0-9]+== .*in loss record [0-9,]+ of [0-9,]+/ {
+      match($0, /==([0-9]+)== .*in loss record ([0-9,]+) of [0-9,]+/, m)
+      record_num = strip_commas(m[2])  # cleans and converts
+      if (record_num > 16) {
+          skipping = 1
+      } else {
+          skipping = 0
+          print
+      }
+      next
+  }
+
+  /^==[0-9]+== $/ {
+      if (!skipping) print
+      skipping = 0  # end of current record
+      next
+  }
+
+  {
+      if (!skipping) print
+  }
+  ' "$input_file" > "$output_file"
+}
+
+
+# Filter valgrind logs and remove all records/stacktraces where X > 16 in:
+# ==[0-9]+== .*in loss record X of Y
+# Write stacktraces with different PIDs to separate files.
+function filter_valgrind_log_to_files() {
+  local input_file="${1:-valgrind-test.log}"
+  local output_file="${2:-valgrind-test-filter.log}"
+  local max_records="${3:-16}"
+
+  awk -v max="$max_records" -v base_out="$output_file" '
+  function strip_commas(s) {
+      gsub(",", "", s)
+      return s + 0
+  }
+
+  function write_record(pid, lines, count, skip,    fname, i) {
+      if (skip) {
+          fname = "valgrind-extra-" pid ".log"
+      } else {
+          fname = base_out
+      }
+      for (i = 1; i <= count; i++) {
+          print lines[i] >> fname
+      }
+      close(fname)
+  }
+
+  /==[0-9]+== .*in loss record [0-9,]+ of [0-9,]+/ {
+      # Flush previous buffered record
+      if (in_record) {
+          write_record(current_pid, record_lines, lines_count, skip_record)
+      }
+
+      match($0, /==([0-9]+)== .*in loss record ([0-9,]+) of [0-9,]+/, m)
+      current_pid = m[1]
+      current_record_num = strip_commas(m[2])
+      in_record = 1
+      skip_record = (current_record_num > max)
+      delete record_lines
+      lines_count = 0
+      record_lines[++lines_count] = $0
+      next
+  }
+
+  /^==[0-9]+==\s*$/ {
+      if (in_record) {
+          record_lines[++lines_count] = $0
+          write_record(current_pid, record_lines, lines_count, skip_record)
+          in_record = 0
+          lines_count = 0
+          next
+      }
+  }
+
+  {
+      if (in_record) {
+          record_lines[++lines_count] = $0
+      } else {
+          # Always output non-record lines (like LEAK SUMMARY)
+          print >> base_out
+      }
+  }
+
+  END {
+      # Final flush
+      if (in_record) {
+          write_record(current_pid, record_lines, lines_count, skip_record)
+      }
+  }
+  ' "$input_file"
+}
+
+
+# Clone git repository if REPO_DIR doesn't exist.
+# Then checkout to a commit_id, a tag, or a branch.
+function setup_git_repo() {
+    if [ $# -ne 3 ]; then
+        echo "Usage: setup_git_repo <GIT_REPO> <GIT_BRANCH/COMMIT> <REPO_DIR>"
+        return 1
+    fi
+
+    local GIT_REPO=$1
+    local GIT_BRANCH=$2
+    local REPO_DIR=$3
+
+    if [ ! -d "$REPO_DIR" ]; then
+        echo "Cloning repository..."
+        git clone "$GIT_REPO" "$REPO_DIR" || { echo "Error: git clone failed"; return 1; }
+    fi
+
+    pushd "$REPO_DIR" || { echo "Error: Cannot enter directory $REPO_DIR"; return 1; }
+
+    git remote set-url origin "$GIT_REPO"
+    git fetch --all --tags
+
+    git reset --hard
+    git clean -xdf
+
+    # Try different checkout approaches
+    if ! git checkout -B "$GIT_BRANCH" --track "origin/$GIT_BRANCH" 2>/dev/null &&
+    ! git checkout "tags/$GIT_BRANCH" 2>/dev/null &&
+    ! git checkout "$GIT_BRANCH" 2>/dev/null; then
+        echo "Error: git checkout $GIT_BRANCH failed"
+        popd
+        return 1
+    fi
+
+    git submodule update --init --recursive
+    popd
+}

--- a/jenkins/percona-server-sanitizers-epyc9654-noble.yml
+++ b/jenkins/percona-server-sanitizers-epyc9654-noble.yml
@@ -1,0 +1,311 @@
+- job-template:
+    name: percona-server-{ps_version}_{sanitizer}_epyc9654-noble
+    node: 'as-1015cs-tnr'  # restricted to specific node
+    description: |
+        Builds and MTR testing for Percona Server<BR><BR>
+        <b>Do not make changes to the pipeline definition via the web interface!<br>
+        (Do not use 'Configure' option on the left for changing the pipeline definition)<br></b>
+        Change <a href="https://github.com/Percona-Lab/ps-build/blob/8.x/jenkins/percona-server-sanitizers-epyc9654-noble.yml">percona-server-sanitizers-epyc9654-noble.yml</a> instead.</b><br>
+        Then update pipeline with "jenkins-jobs --server ps80.cd update jenkins/percona-server-sanitizers-epyc9654-noble.yml".
+    properties:
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 16
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 16
+    parameters:
+    - string:
+        name: GIT_REPO
+        default: "https://github.com/percona/percona-server"
+        description: URL to percona-server repository
+    - string:
+        name: BRANCH
+        default: "{branch_name}"
+        description: Tag/Branch/Commit for percona-server repository
+    #- choice:
+    #    name: DOCKER_OS
+    #    choices:
+    #    - ubuntu-noble
+    #    description: OS version for compilation
+    - choice:
+        name: CMAKE_BUILD_TYPE
+        choices:
+        - Debug
+        - RelWithDebInfo
+        description: Type of build to produce
+    #- choice:
+    #    name: JOB_CMAKE
+    #    choices:
+    #    - /usr/bin/cmake
+    #    description: path to cmake binary
+    - choice:
+        name: COMPILER
+        choices:
+        - gcc-14
+        - gcc-13
+        description: compiler version
+    - string:
+        name: ANALYZER_OPTS
+        default: '{sanitizer_opts}'
+        description: 'Analyzer options for the build'
+    - choice:
+        name: WITH_ROCKSDB
+        choices:
+        - "ON"
+        - "OFF"
+        description: Compile RocksDB engine
+    - choice:
+        name: WITH_ROUTER
+        choices:
+        - "ON"
+        - "OFF"
+        description: Whether to build MySQL Router
+    - choice:
+        name: WITH_MYSQLX
+        choices:
+        - "ON"
+        - "OFF"
+        description: Whether to build with support for X Plugin
+    - string:
+        name: CMAKE_OPTS
+        default: "-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DROCKSDB_DISABLE_MARCH_NATIVE=1"
+        description: cmake options
+    - string:
+        name: MAKE_OPTS
+        default: "-j96"
+        description: make options, like VERBOSE=1
+    #- choice:
+    #    name: CI_FS_MTR
+    #    choices:
+    #    - "yes"
+    #    - "no"
+    #    description: Run case-insensetive MTR tests
+    - choice:
+        name: WITH_PS_PROTOCOL
+        choices:
+        - "yes"
+        - "no"
+        description: Run MTR tests with --ps-protocol
+    #- choice:
+    #    name: ZEN_FS_MTR
+    #    choices:
+    #    - "no"
+    #    - "yes"
+    #    description: Run ZenFS MTR tests
+    - string:
+        name: MTR_ARGS
+        default: '{mtr_opts}'
+        description: |
+            mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report
+    - string:
+        name: MTR_REPEAT
+        default: "1"
+        description: Run each test N number of times, --repeat=N
+    - string:
+        name: MTR_SUITES
+        default: '{mtr_suites}'
+        description: "list of MTR suites to test"
+    - choice:
+        name: SKIP_BUILD
+        choices:
+        - "no"
+        - "yes"
+        description: "skip build and use binaries from the last build"
+    - choice:
+        name: KEEP_BUILD
+        choices:
+        - "no"
+        - "yes"
+        description: "should we keep intermediate build files (can be accessed with SSH to the server)"
+    #- choice:
+    #    name: WITH_KEYRING_VAULT
+    #    choices:
+    #    - "ON"
+    #    - "OFF"
+    #    description: Whether to build with support for keyring_vault Plugin
+    #- choice:
+    #    name: KEYRING_VAULT_MTR
+    #    choices:
+    #    - "no"
+    #    - "yes"
+    #    description: Run mtr --suite=keyring_vault
+    #- string:
+    #    name: KEYRING_VAULT_V1_VERSION
+    #    default: "0.9.6"
+    #    description: Specifies version of Hashicorp Vault for V1 tests
+    #- string:
+    #    name: KEYRING_VAULT_V2_VERSION
+    #    default: "1.9.0"
+    #    description: Specifies version of Hashicorp Vault for V2 tests
+    - string:
+        name: PS_BUILD_REPO
+        default: '{scripts_repo}'
+        description: URL to ps-build repository
+    - string:
+        name: PS_BUILD_BRANCH
+        default: '{scripts_branch}'
+        description: Tag/Branch/Commit for ps-build repository
+    can_roam: false
+    disabled: false
+    block_build_when_downstream_building: false
+    block_build_when_upstream_building: false
+    triggers: []
+    concurrent_build: false
+    builders:
+      - shell:
+          command: |
+            #!/bin/bash
+            uname -a
+            df -h
+            echo WORKSPACE=$WORKSPACE
+            pwd
+            ls -la
+            rm -rf *
+
+            # Change aio-max-nr
+            cat /proc/sys/fs/aio-max-nr
+            sudo sysctl -w fs.aio-max-nr=1048576
+            cat /proc/sys/fs/aio-max-nr
+
+            ulimit -n
+            ulimit -n 1048576
+            ulimit -n
+
+            export WORKER_NO=1
+            export DOCKER_OS=ubuntu-noble
+
+            # Display the user and the environment variables
+            echo "User: $(whoami) USER=$USER"
+            echo GIT_REPO=$GIT_REPO
+            echo BRANCH=$BRANCH
+            echo DOCKER_OS=$DOCKER_OS
+            echo CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+            echo JOB_CMAKE=$JOB_CMAKE
+            echo ANALYZER_OPTS=$ANALYZER_OPTS
+            echo WITH_ROCKSDB=$WITH_ROCKSDB
+            echo WITH_ROUTER=$WITH_ROUTER
+            echo WITH_MYSQLX=$WITH_MYSQLX
+            echo CMAKE_OPTS=$CMAKE_OPTS
+            echo MAKE_OPTS=$MAKE_OPTS
+            echo CI_FS_MTR=$CI_FS_MTR
+            echo WITH_PS_PROTOCOL=$WITH_PS_PROTOCOL
+            echo ZEN_FS_MTR=$ZEN_FS_MTR
+            echo MTR_ARGS=$MTR_ARGS
+            echo MTR_REPEAT=$MTR_REPEAT
+            echo MTR_SUITES=$MTR_SUITES
+            echo SKIP_BUILD=$SKIP_BUILD
+            # echo WITH_KEYRING_VAULT=$WITH_KEYRING_VAULT
+            # echo KEYRING_VAULT_MTR=$KEYRING_VAULT_MTR
+            # echo KEYRING_VAULT_V1_VERSION=$KEYRING_VAULT_V1_VERSION
+            # echo KEYRING_VAULT_V2_VERSION=$KEYRING_VAULT_V2_VERSION
+            echo PS_BUILD_REPO=$PS_BUILD_REPO
+            echo PS_BUILD_BRANCH=$PS_BUILD_BRANCH
+
+            export PS_BUILD_DIR=/mnt/storage2/ps-build
+            export WORK_DIR=/mnt/storage2/ps-build-$PS_BUILD_BRANCH-workspace
+
+            wget https://raw.githubusercontent.com/Percona-Lab/ps-build/refs/heads/8.x/jenkins/jenkins-common.sh
+            wget https://raw.githubusercontent.com/Percona-Lab/ps-build/refs/heads/8.x/jenkins/ps-common.sh
+            source ./jenkins-common.sh
+            source ./ps-common.sh
+            build_and_run_sanitizer
+            cd $WORKSPACE
+            rm -f jenkins-common.sh ps-common.sh
+            ls -la
+
+    publishers:
+      - junit:
+          results: '*.xml'
+          keep-long-stdio: true
+          health-scale-factor: 1.0
+          allow-empty-results: false
+      - archive:
+          artifacts: "*.tar.gz, *.log*, *.txt, *.xml"
+          allow_empty_archive: false
+          only_if_successful: false
+          fingerprint: false
+          default_excludes: true
+          case_sensitive: true
+          follow_symlinks: false
+    build_wrappers: []
+
+
+- project:
+    name: ASAN-8.0
+    sanitizer: ASAN
+    ps_version: 8.0
+    branch_name: release-8.0.42-33
+    sanitizer_opts: '-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON'
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --parallel=96
+    mtr_suites: "audit_null,audit_log,audit_log_filter,binlog_57_decryption,data_masking,auth_sec,binlog,binlog_gtid,binlog_nogtid,clone,collations,connection_control,encryption,federated,funcs_2,gcol,gis,information_schema,innodb,innodb_fts,innodb_gis,innodb_undo,innodb_zip,interactive_utilities,json,main,opt_trace,parts,perfschema,query_rewrite_plugins,rpl,rpl_gtid,rpl_nogtid,secondary_engine,service_status_var_registration,service_sys_var_registration,service_udf_registration,sys_vars,sysschema,test_service_sql_api,test_services,x,component_keyring_file,percona-pam-for-mysql,component_encryption_udf,component_masking_functions,procfs,rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,rpl_encryption,engines/iuds,engines/funcs,funcs_1,group_replication,jp,stress"
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: 8.0
+    jobs:
+      - percona-server-{ps_version}_{sanitizer}_epyc9654-noble
+
+- project:
+    name: VALGRIND-8.0
+    sanitizer: VALGRIND
+    ps_version: 8.0
+    branch_name: release-8.0.42-33
+    sanitizer_opts: '-DWITH_VALGRIND=ON'
+    mtr_opts: --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
+    mtr_suites: "audit_null,audit_log,audit_log_filter,binlog_57_decryption,data_masking,auth_sec,binlog,binlog_gtid,binlog_nogtid,clone,collations,connection_control,encryption,federated,funcs_2,gcol,gis,information_schema,innodb,innodb_fts,innodb_gis,innodb_undo,innodb_zip,interactive_utilities,json,main,opt_trace,parts,perfschema,query_rewrite_plugins,rpl,rpl_gtid,rpl_nogtid,secondary_engine,service_status_var_registration,service_sys_var_registration,service_udf_registration,sys_vars,sysschema,test_service_sql_api,test_services,x,component_keyring_file,percona-pam-for-mysql,component_encryption_udf,component_masking_functions,procfs,rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,rpl_encryption,engines/iuds,engines/funcs,funcs_1,group_replication,jp,stress"
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: 8.0
+    jobs:
+      - percona-server-{ps_version}_{sanitizer}_epyc9654-noble
+
+
+- project:
+    name: ASAN-8.4
+    sanitizer: ASAN
+    ps_version: 8.4
+    branch_name: release-8.4.5-5
+    sanitizer_opts: '-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON'
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --parallel=96
+    mtr_suites: "audit_null,auth_sec,binlog,binlog_gtid,binlog_nogtid,clone,collations,connection_control,encryption,federated,funcs_2,gcol,gis,information_schema,innodb,innodb_fts,innodb_gis,innodb_undo,innodb_zip,interactive_utilities,json,main,opt_trace,parts,perfschema,query_rewrite_plugins,rpl,rpl_gtid,rpl_nogtid,secondary_engine,service_status_var_registration,service_sys_var_registration,service_udf_registration,sys_vars,sysschema,test_service_sql_api,test_services,x,component_keyring_file,component_audit_log_filter,component_encryption_udf,percona,percona_innodb,percona-pam-for-mysql,component_masking_functions,procfs,rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,rpl_encryption,engines/iuds,engines/funcs,funcs_1,group_replication,jp,stress"
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: 8.x
+    jobs:
+      - percona-server-{ps_version}_{sanitizer}_epyc9654-noble
+
+- project:
+    name: VALGRIND-8.4
+    sanitizer: VALGRIND
+    ps_version: 8.4
+    branch_name: release-8.4.5-5
+    sanitizer_opts: '-DWITH_VALGRIND=ON'
+    mtr_opts: --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
+    mtr_suites: "audit_null,auth_sec,binlog,binlog_gtid,binlog_nogtid,clone,collations,connection_control,encryption,federated,funcs_2,gcol,gis,information_schema,innodb,innodb_fts,innodb_gis,innodb_undo,innodb_zip,interactive_utilities,json,main,opt_trace,parts,perfschema,query_rewrite_plugins,rpl,rpl_gtid,rpl_nogtid,secondary_engine,service_status_var_registration,service_sys_var_registration,service_udf_registration,sys_vars,sysschema,test_service_sql_api,test_services,x,component_keyring_file,component_audit_log_filter,component_encryption_udf,percona,percona_innodb,percona-pam-for-mysql,component_masking_functions,procfs,rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,rpl_encryption,engines/iuds,engines/funcs,funcs_1,group_replication,jp,stress"
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: 8.x
+    jobs:
+      - percona-server-{ps_version}_{sanitizer}_epyc9654-noble
+
+
+- project:
+    name: ASAN-9.x
+    sanitizer: ASAN
+    ps_version: 9.x
+    branch_name: release-9.2.0-1
+    sanitizer_opts: '-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON'
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --parallel=96
+    mtr_suites: "audit_null,auth_sec,binlog,binlog_gtid,binlog_nogtid,clone,collations,connection_control,encryption,federated,funcs_2,gcol,gis,information_schema,innodb,innodb_fts,innodb_gis,innodb_undo,innodb_zip,interactive_utilities,json,main,opt_trace,parts,perfschema,query_rewrite_plugins,rpl,rpl_gtid,rpl_nogtid,secondary_engine,service_status_var_registration,service_sys_var_registration,service_udf_registration,sys_vars,sysschema,test_service_sql_api,test_services,x,component_keyring_file,component_audit_log_filter,component_encryption_udf,percona,percona_innodb,percona-pam-for-mysql,component_masking_functions,procfs,rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,rpl_encryption,engines/iuds,engines/funcs,funcs_1,group_replication,jp,stress"
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: 8.x
+    jobs:
+      - percona-server-{ps_version}_{sanitizer}_epyc9654-noble
+
+- project:
+    name: VALGRIND-9.x
+    sanitizer: VALGRIND
+    ps_version: 9.x
+    branch_name: release-9.2.0-1
+    sanitizer_opts: '-DWITH_VALGRIND=ON'
+    mtr_opts: --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
+    mtr_suites: "audit_null,auth_sec,binlog,binlog_gtid,binlog_nogtid,clone,collations,connection_control,encryption,federated,funcs_2,gcol,gis,information_schema,innodb,innodb_fts,innodb_gis,innodb_undo,innodb_zip,interactive_utilities,json,main,opt_trace,parts,perfschema,query_rewrite_plugins,rpl,rpl_gtid,rpl_nogtid,secondary_engine,service_status_var_registration,service_sys_var_registration,service_udf_registration,sys_vars,sysschema,test_service_sql_api,test_services,x,component_keyring_file,component_audit_log_filter,component_encryption_udf,percona,percona_innodb,percona-pam-for-mysql,component_masking_functions,procfs,rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,rpl_encryption,engines/iuds,engines/funcs,funcs_1,group_replication,jp,stress"
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: 8.x
+    jobs:
+      - percona-server-{ps_version}_{sanitizer}_epyc9654-noble

--- a/jenkins/ps-common.sh
+++ b/jenkins/ps-common.sh
@@ -1,0 +1,62 @@
+#!/bin/echo This script should be sourced in a shell, not executed directly
+
+function build_and_run_sanitizer() {
+    if [[ -z "$PS_BUILD_DIR" ]] || [[ -z "$WORK_DIR" ]] || [[ -z "$WORKSPACE" ]]; then
+        echo "Error: PS_BUILD_DIR or WORK_DIR or WORKSPACE is not set."
+        return 1
+    fi
+
+    # RESULTS_DIR has to be equal to RESULTS_DIR variable defined in /local/test-binary-parallel-mtr
+    local RESULTS_DIR=$WORK_DIR/results
+
+    # clear results from the last run
+    if [[ -d $RESULTS_DIR ]]; then
+        ls -la $RESULTS_DIR
+        rm -rf $RESULTS_DIR
+    fi
+
+    # download "ps-build" repo and share it with 8.0/8.x branches
+    if [[ ! -d "$PS_BUILD_DIR" ]]; then
+        sudo mkdir -p $PS_BUILD_DIR
+        sudo chown $USER:$USER $PS_BUILD_DIR
+        git clone --branch 8.0 "$PS_BUILD_REPO" "$PS_BUILD_DIR" || { echo "Error: git clone failed"; return 1; }
+        cd $PS_BUILD_DIR
+        # call /docker/install-deps from 8.0 branch
+        sudo ./docker/install-deps
+    fi
+
+    setup_git_repo $PS_BUILD_REPO $PS_BUILD_BRANCH $PS_BUILD_DIR
+    cd $PS_BUILD_DIR
+
+    # build from sources unless SKIP_BUILD=yes
+    if [ "$SKIP_BUILD" != "yes" ]; then
+        sudo rm -rf $WORK_DIR
+        sudo mkdir -p $WORK_DIR
+        sudo chown $USER:$USER $WORK_DIR
+        sudo git clean -xdf
+        # sudo chown -R $USER:$USER sources
+        # /local/checkout uses env variables GIT_REPO and BRANCH
+        ./local/checkout
+        ./local/build-binary $WORK_DIR
+    fi
+
+    ./local/test-binary-parallel-mtr $WORK_DIR | tee $WORK_DIR/mtr-test.log
+
+    cd $WORK_DIR
+    mv mtr-test.log mtr-test.full-log
+    filter_valgrind_log mtr-test.full-log mtr-test.log
+    zstd -c mtr-test.log > mtr-test.log.zst
+
+    grep -A16 "Conditional jump or move depends on uninitialised" mtr-test.log >mtr-test-valgrind-ConditionalJump.log || :
+    grep -A16 "are definitely lost"         mtr-test.log >mtr-test-valgrind-definitelyLost.log || :
+    grep -B128 -A128 "Invalid read of size" mtr-test.log >mtr-test-valgrind-InvalidRead.log || :
+    grep -A16 "ERROR: .*Sanitizer"          mtr-test.log >mtr-test-Errors-Sanitizers.log || :
+    grep -A16 "ERROR: AddressSanitizer"     mtr-test.log >mtr-test-Errors-AddressSanitizer.log || :
+    grep -A16 "ERROR: LeakSanitizer"        mtr-test.log >mtr-test-Errors-LeakSanitizer.log || :
+
+    ls -l
+    cp $WORK_DIR/*.log* $WORKSPACE/
+    cp $WORK_DIR/*.txt $WORKSPACE/
+    cp $RESULTS_DIR/*.xml $WORKSPACE/
+    cp $RESULTS_DIR/*.tar.gz $WORKSPACE/
+}


### PR DESCRIPTION
1. Add a new pipeline that uses `as-1015cs-tnr` node (Epyc 9654) for Valgrind and ASan. The pipeline doesn't use Docker but runs directly on Ubuntu Noble.
2. The whole build and test logic is introduced in `build_and_run_sanitizer` function in `ps-common.sh`.
3. `jenkins-common.sh` contatins `filter_valgrind_log` and `setup_git_repo` which may be used by PXC scripts.