### PR TITLE
PKG-473: Additional pipeline fixes for ccache implementation

### DIFF
--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -240,7 +240,7 @@ void build(String SCRIPT) {
                     if [ \$(docker ps -q | wc -l) -ne 0 ]; then
                         docker ps -q | xargs docker stop --time 1 || :
                     fi
-                    eval USE_CCACHE=yes CCACHE_MAXSIZE=${CCACHE_MAXSIZE} KEEP_BUILD=yes ${SCRIPT} ${DOCKER_OS} ${WORKSPACE}/${WORK_DIR}
+                    eval USE_CCACHE=yes CCACHE_MAXSIZE=${env.CCACHE_MAXSIZE} KEEP_BUILD=yes ${SCRIPT} ${DOCKER_OS} ${WORKSPACE}/${WORK_DIR}
                 " 2>&1 | tee build.log
 
                 echo Archive build log: \$(date -u "+%s")
@@ -638,6 +638,9 @@ pipeline {
                         checkoutSources()
 
                         script {
+                            // Set ccache size as environment variable
+                            env.CCACHE_MAXSIZE = CCACHE_MAXSIZE
+                            
                             // Set BUILD_PARAMS_TYPE based on ANALYZER_OPTS
                             if (env.ANALYZER_OPTS) {
                                 if (env.ANALYZER_OPTS.contains('ASAN')) {
@@ -698,22 +701,24 @@ pipeline {
                         build('./docker/run-build')
 
                         // Upload ccache using shared library
-                        // Determine retention days based on build type
-                        def retentionDays = (env.BUILD_PARAMS_TYPE == 'asan' || env.BUILD_PARAMS_TYPE == 'valgrind') ?
-                            CACHE_RETENTION_DAYS_SANITIZER : CACHE_RETENTION_DAYS_NORMAL
+                        script {
+                            // Determine retention days based on build type
+                            def retentionDays = (env.BUILD_PARAMS_TYPE == 'asan' || env.BUILD_PARAMS_TYPE == 'valgrind') ?
+                                CACHE_RETENTION_DAYS_SANITIZER : CACHE_RETENTION_DAYS_NORMAL
 
-                        ccacheUpload([
-                            awsCredentialsId: AWS_CREDENTIALS_ID,
-                            buildParamsType: env.BUILD_PARAMS_TYPE,
-                            cacheRetentionDays: retentionDays,
-                            cloud: params.CLOUD,
-                            cmakeBuildType: env.CMAKE_BUILD_TYPE,
-                            dockerOs: env.DOCKER_OS,
-                            serverVersion: SERVER_VERSION,
-                            s3Bucket: S3_ROOT_DIR + '/',
-                            toolset: env.TOOLSET,
-                            workspace: env.WORKSPACE
-                        ])
+                            ccacheUpload([
+                                awsCredentialsId: AWS_CREDENTIALS_ID,
+                                buildParamsType: env.BUILD_PARAMS_TYPE,
+                                cacheRetentionDays: retentionDays,
+                                cloud: params.CLOUD,
+                                cmakeBuildType: env.CMAKE_BUILD_TYPE,
+                                dockerOs: env.DOCKER_OS,
+                                serverVersion: SERVER_VERSION,
+                                s3Bucket: S3_ROOT_DIR + '/',
+                                toolset: env.TOOLSET,
+                                workspace: env.WORKSPACE
+                            ])
+                        }
 
                         script {
                             boolean archive_public_url = false


### PR DESCRIPTION
## Summary
This PR contains the remaining fix needed for the ccache implementation to work correctly in Jenkins.

## Issue Fixed
**Missing property error**: "No such property: CCACHE_MAXSIZE" - Fixed by setting it as environment variable

## Changes
- Set  as an environment variable using the idiomatic  pattern
- This allows the constant defined at the top of the pipeline to be accessible in shell scripts

## Testing
- Tested on https://ps80.cd.percona.com/job/PKG-473-ccache-test/
- Build completed successfully with ccache working (5,120 files cached, 0.51GB cache size)
- Error is resolved

## Related
- Original implementation: #463 (merged June 25)
- First fix: #469 (merged June 26)
- This PR contains the additional fix discovered during testing
- Jira ticket: PKG-473