### PR TITLE
PKG-473: Fix Docker mount dependency issue for ccache directory

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -28,6 +28,9 @@ WORK_DIR=${2:-$ROOT_DIR/${SOURCE_IMAGE}_${CMAKE_BUILD_TYPE}}
 rm -rf $WORK_DIR
 mkdir $WORK_DIR
 
+# Ensure .ccache directory exists for Docker mounting
+mkdir -p "${ROOT_DIR}/.ccache"
+
 docker run --rm \
     --cap-add SYS_PTRACE \
     --mount type=bind,source=${SOURCES_DIR},destination=/tmp/sources \


### PR DESCRIPTION
## Summary
Fixes Docker mount failure when .ccache directory doesn't exist.

## Problem
Docker script assumes .ccache directory exists but dependency can be violated:
- Jenkins creates `${env.WORKSPACE}/.ccache` 
- Docker expects `${ROOT_DIR}/.ccache`
- Path mismatch or creation failure causes mount error

## Solution
```bash
mkdir -p "${ROOT_DIR}/.ccache"
```

Always create directory before Docker mount - simple, low-risk approach.