### PR TITLE
PKG-473: Fix ccache permissions inside Docker container

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -68,11 +68,11 @@ docker run --rm \
     export DOCKER_OS='${SOURCE_IMAGE}'
     export KEEP_BUILD='${KEEP_BUILD}'
 
-    sudo chown mysql:mysql /tmp/work /tmp/sources /tmp/sources/mysql-test/collections /tmp/sources/storage/rocksdb/rocksdb/util /tmp/sources/rocksdb/util || :
+    sudo chown mysql:mysql /tmp/work /tmp/sources /tmp/sources/mysql-test/collections /tmp/sources/storage/rocksdb/rocksdb/util /tmp/sources/rocksdb/util /tmp/ccache || :
     cp -r /tmp/source_downloads /tmp/work/source_downloads
 
     bash -x /tmp/scripts/build-binary /tmp/work /tmp/sources
 
     rm -rf /tmp/work/source_downloads
-    sudo chown $(id -u):$(id -g) /tmp/work /tmp/sources /tmp/sources/mysql-test/collections /tmp/sources/storage/rocksdb/rocksdb/util /tmp/sources/rocksdb/util || :
+    sudo chown $(id -u):$(id -g) /tmp/work /tmp/sources /tmp/sources/mysql-test/collections /tmp/sources/storage/rocksdb/rocksdb/util /tmp/sources/rocksdb/util /tmp/ccache || :
 "


### PR DESCRIPTION
## Summary
Fixes ccache permission issues inside Docker container by adding `/tmp/ccache` to chown commands.

## Problem
After PR #472 fixed the directory creation issue, another problem can occur:
- Docker mounts `.ccache` at `/tmp/ccache` 
- The mysql user needs write permissions during build
- Without proper permissions, ccache fails with "permission denied" errors

## Solution
Add `/tmp/ccache` to both chown commands in `docker/run-build`:
1. Before build: `chown mysql:mysql ... /tmp/ccache`
2. After build: `chown $(id -u):$(id -g) ... /tmp/ccache`

This ensures ccache can write cache files properly during the build process.

## Related to
- PR #472 (creates .ccache directory)
- PKG-473 (ccache implementation)