### PR TITLE
PKG-473: Add missing USE_CCACHE parameter to Jenkins job definition

### DIFF
--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -87,7 +87,14 @@
     - string:
         name: MAKE_OPTS
         default:
-        description: make options, like VERBOSE=1
+        description: make options
+    - choice:
+        name: USE_CCACHE
+        choices:
+        - "yes"
+        - "no"
+        default: "yes"
+        description: Use ccache to speed up compilation (80-90% faster rebuilds)
     - choice:
         name: CI_FS_MTR
         choices:

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -240,7 +240,7 @@ void build(String SCRIPT) {
                     if [ \$(docker ps -q | wc -l) -ne 0 ]; then
                         docker ps -q | xargs docker stop --time 1 || :
                     fi
-                    eval USE_CCACHE=yes CCACHE_MAXSIZE=${env.CCACHE_MAXSIZE} KEEP_BUILD=yes ${SCRIPT} ${DOCKER_OS} ${WORKSPACE}/${WORK_DIR}
+                    eval USE_CCACHE=${params.USE_CCACHE} CCACHE_MAXSIZE=${env.CCACHE_MAXSIZE} KEEP_BUILD=yes ${SCRIPT} ${DOCKER_OS} ${WORKSPACE}/${WORK_DIR}
                 " 2>&1 | tee build.log
 
                 echo Archive build log: \$(date -u "+%s")


### PR DESCRIPTION
## Summary
Fixes a critical issue where the USE_CCACHE parameter was missing from the Jenkins job definition, causing ccache to be forcibly enabled on all builds.

## Changes Made
1. **Added USE_CCACHE parameter** to `jenkins/param-parallel-mtr.yml`
   - Default value: "yes" 
   - Allows users to disable ccache via Jenkins UI
   
2. **Fixed pipeline script** to use `params.USE_CCACHE` instead of hardcoded `"yes"`
   - Enables proper parameter control flow
   - Allows testing with USE_CCACHE=no on Hetzner

## Problem Context
- Build #112 failed on Hetzner with ccache enabled
- Build #107 succeeded on AWS before ccache implementation
- Root cause: Missing parameter prevented users from disabling ccache
- This fix allows USE_CCACHE=no workaround while S3 access is investigated

Related to: [Percona-Lab/jenkins-pipelines#3356](https://github.com/Percona-Lab/jenkins-pipelines/pull/3356)

