### PR TITLE
PS-10120: Jenkins jobs report failed (red cross) status even though the worker was not interrupted

### DIFF
--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -269,7 +269,7 @@
 - project:
     name: param-parallel-mtr-8.0
     ps_version: 8.0
-    ps_version_no_dot: 8_0
+    ps_version_no_dot: '8_0'
     branch_name: release-8.0.42-33
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
@@ -287,7 +287,7 @@
 - project:
     name: param-parallel-mtr-8.x
     ps_version: 8.x
-    ps_version_no_dot: 8_x
+    ps_version_no_dot: '8_x'
     branch_name: release-8.4.5-5
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
@@ -305,7 +305,7 @@
 - project:
     name: param-parallel-mtr-9.x
     ps_version: 9.x
-    ps_version_no_dot: 9_x
+    ps_version_no_dot: '9_x'
     branch_name: release-9.2.0-1
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0


### PR DESCRIPTION
The generated job was using
`${TRIGGERED_BUILD_NUMBERS_percona_server_80_pipeline_parallel_mtr}`
instead of
`${TRIGGERED_BUILD_NUMBERS_percona_server_8_0_pipeline_parallel_mtr}`