### PR TITLE
PS-10120: Improve `percona-server-x.y-param-parallel-mtr` and `percona-server-x.y-pipeline-parallel-mtr` pipelines

### DIFF
--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -187,7 +187,7 @@
         description: "MTR workers count for standalone tests"
     - bool:
         name: ALLOW_ABORTED_WORKERS_RERUN
-        default: true
+        default: false
         description: "Rerun aborted workers"
     - string:
         name: SLACK_CHANNEL

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -661,7 +661,7 @@ pipeline {
                             // Extract compiler version for ccache key
                             def CC_COMPILER = env.CC ?: 'gcc'
 
-                            env.COMPILER_VERSION = sh(returnStdout: true, script: """
+                            env.COMPILER_VERSION = sh(returnStdout: true, script: """#!/bin/bash
                                 COMPILER="${CC_COMPILER}"
                                 if [[ "\$COMPILER" == *"clang"* ]]; then
                                     \$COMPILER --version | grep -o "clang version.*" | awk '{print \$3}'

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -91,7 +91,7 @@ void downloadFilesForTests() {
     downloadFileFromS3("${BUILD_TAG_BINARIES}", 'binary.tar.gz', "./${WORK_DIR}/binary.tar.gz")
 }
 
-void prepareWorkspace(Integer WORKER_ID) {
+void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
         sh """
             echo "prepareWorkspace for MTR worker ${WORKER_ID}"
@@ -100,10 +100,23 @@ void prepareWorkspace(Integer WORKER_ID) {
             # it's safe to use "git clean" as "sources/" are ignored with ".gitignore"
             sudo git clean -xdf
 
-            # sources exists only for WORKER #1 but not for retry/re-runs
-            if [ -d sources ]; then
-                sudo git -C sources reset --hard
-                sudo git -C sources clean -xdf
+            # "sources" required for running unit tests are valid only for "Test 1" (WORKER #1) but not for retry/re-runs
+            if [ "$WORKER_ID" = "1" ] && [ "$UNIT_TESTS" != "false" ]; then
+                if [ -d sources ]; then
+                    sudo cat sources/MYSQL_VERSION || :
+                    if ! sudo git -C sources status >/dev/null 2>&1; then
+                        echo "Warning: Git repo in ./sources is broken, removing it. It should happen only for re-runs."
+                        sudo GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -C sources -c safe.directory="$WORKSPACE/sources" log --oneline -10 || :
+                        sudo rm -rf sources
+                    else
+                        sudo git -C sources log --oneline -10
+                        sudo git -C sources reset --hard
+                        sudo git -C sources clean -xdf
+                        sudo git -C sources submodule update --init || :
+                    fi
+                else
+                    echo "Warning: Missing 'sources' for MTR worker ${WORKER_ID}. It should happen only for re-runs."
+                fi
             fi
 
             if [ -f /usr/bin/yum ]; then
@@ -196,15 +209,19 @@ void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDA
             git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
 
             script {
-                prepareWorkspace(WORKER_ID)
+                prepareWorkspace(WORKER_ID, UNIT_TESTS)
                 downloadFilesForTests()
                 doTests(WORKER_ID.toString(), SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
             }
+
+            echo "[INFO] Worker ${WORKER_ID} finished MTR testing."
 
             // This is questionable. Do we need result XMLs in S3 cache while Jenkins archives them as well?
             syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')
             step([$class: 'JUnitResultArchiver', testResults: "${WORK_DIR}/results/*.xml", healthScaleFactor: 1.0])
             archiveArtifacts "${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
+
+            echo "[INFO] Worker ${WORKER_ID} completed successfully."
         } catch (err) {
             echo "[WARNING] Worker ${WORKER_ID} failed with error: ${err}"
             throw err // rethrow so outer catchError or pipeline failure handling still works
@@ -787,6 +804,7 @@ pipeline {
                                 beforeAgent true
                                 expression { (env.WORKER_1_MTR_SUITES?.trim() || env.MTR_STANDALONE_TESTS?.trim() || env.CI_FS_MTR?.trim() == 'yes' || env.KEYRING_VAULT_MTR?.trim() == 'yes' || env.WITH_PS_PROTOCOL?.trim() == 'yes') }
                             }
+                            // "Test 1" reuses the same instance as "Build" and inherits "sources" which are required for running unit tests
                             // agent { label LABEL }
                             steps {
                                 doTestWorkerJob(1, "${WORKER_1_MTR_SUITES}", "${MTR_STANDALONE_TESTS}", true, env.CI_FS_MTR?.trim() == 'yes', env.KEYRING_VAULT_MTR?.trim() == 'yes', env.WITH_PS_PROTOCOL?.trim() == 'yes')

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -183,40 +183,57 @@ void doTests(String WORKER_ID, String SUITES, String STANDALONE_TESTS = '', bool
     }  // withCredentials
 }
 
-void doTestWorkerJob(Integer WORKER_ID, String SUITES, String STANDALONE_TESTS = '', boolean UNIT_TESTS = false, boolean CIFS_TESTS = false, boolean KV_TESTS = false, boolean PS_PROTOCOL_TESTS = false) {
-    timeout(time: PIPELINE_TIMEOUT, unit: 'HOURS')  {
-        script {
-            echo "JENKINS_SCRIPTS_BRANCH: ${JENKINS_SCRIPTS_BRANCH}"
-            echo "JENKINS_SCRIPTS_REPO: ${JENKINS_SCRIPTS_REPO}"
-            sh 'which git'
-        }
-        git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
-        script {
-            prepareWorkspace(WORKER_ID)
-            downloadFilesForTests()
-            doTests(WORKER_ID.toString(), SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
-        }
+void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDALONE_TESTS = '', boolean UNIT_TESTS = false, boolean CIFS_TESTS = false, boolean KV_TESTS = false, boolean PS_PROTOCOL_TESTS = false) {
+    timeout(time: PIPELINE_TIMEOUT, unit: 'HOURS') {
+        try {
+            script {
+                echo "NODE_NAME = ${env.NODE_NAME}"
+                echo "JENKINS_SCRIPTS_BRANCH: ${JENKINS_SCRIPTS_BRANCH}"
+                echo "JENKINS_SCRIPTS_REPO: ${JENKINS_SCRIPTS_REPO}"
+                sh 'which git'
+            }
 
-        // This is questionable. Do we need resutl XMLs in S3 cache while Jenkins archives them as well?
-        syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')
-        step([$class: 'JUnitResultArchiver', testResults: "${WORK_DIR}/results/*.xml", healthScaleFactor: 1.0])
-        archiveArtifacts "${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
+            git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
+
+            script {
+                prepareWorkspace(WORKER_ID)
+                downloadFilesForTests()
+                doTests(WORKER_ID.toString(), SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
+            }
+
+            // This is questionable. Do we need result XMLs in S3 cache while Jenkins archives them as well?
+            syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')
+            step([$class: 'JUnitResultArchiver', testResults: "${WORK_DIR}/results/*.xml", healthScaleFactor: 1.0])
+            archiveArtifacts "${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
+        } catch (err) {
+            echo "[WARNING] Worker ${WORKER_ID} failed with error: ${err}"
+            throw err // rethrow so outer catchError or pipeline failure handling still works
+        }
     }
 }
 
 void doTestWorkerJobWithGuard(Integer WORKER_ID, String SUITES, String STANDALONE_TESTS = '', boolean UNIT_TESTS = false, boolean CIFS_TESTS = false, boolean KV_TESTS = false, boolean PS_PROTOCOL_TESTS = false) {
     catchError(buildResult: 'UNSTABLE') {
         script {
-            echo "NODE_NAME = ${env.NODE_NAME}"
             WORKER_ABORTED[WORKER_ID] = true
             echo "WORKER_${WORKER_ID.toString()}_ABORTED = true"
         }
-        doTestWorkerJob(WORKER_ID, SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
+        doTestWorkerJobWithoutGuard(WORKER_ID, SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
         script {
             WORKER_ABORTED[WORKER_ID] = false
             echo "WORKER_${WORKER_ID.toString()}_ABORTED = false"
         }
     } // catch
+}
+
+void doTestWorkerJob(Integer WORKER_ID, String SUITES, String STANDALONE_TESTS = '', boolean UNIT_TESTS = false, boolean CIFS_TESTS = false, boolean KV_TESTS = false, boolean PS_PROTOCOL_TESTS = false) {
+    script {
+        if (env.ALLOW_ABORTED_WORKERS_RERUN == 'true') {
+            doTestWorkerJobWithGuard(WORKER_ID, SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
+        } else {
+            doTestWorkerJobWithoutGuard(WORKER_ID, SUITES, STANDALONE_TESTS, UNIT_TESTS, CIFS_TESTS, KV_TESTS, PS_PROTOCOL_TESTS)
+        }
+    }
 }
 
 void checkoutSources() {
@@ -772,7 +789,7 @@ pipeline {
                             }
                             // agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(1, "${WORKER_1_MTR_SUITES}", "${MTR_STANDALONE_TESTS}", true, env.CI_FS_MTR?.trim() == 'yes', env.KEYRING_VAULT_MTR?.trim() == 'yes', env.WITH_PS_PROTOCOL?.trim() == 'yes')
+                                doTestWorkerJob(1, "${WORKER_1_MTR_SUITES}", "${MTR_STANDALONE_TESTS}", true, env.CI_FS_MTR?.trim() == 'yes', env.KEYRING_VAULT_MTR?.trim() == 'yes', env.WITH_PS_PROTOCOL?.trim() == 'yes')
                             }
                         }
                         stage('Test 2') {
@@ -782,7 +799,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(2, "${WORKER_2_MTR_SUITES}")
+                                doTestWorkerJob(2, "${WORKER_2_MTR_SUITES}")
                             }
                         }
                         stage('Test 3') {
@@ -792,7 +809,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(3, "${WORKER_3_MTR_SUITES}")
+                                doTestWorkerJob(3, "${WORKER_3_MTR_SUITES}")
                             }
                         }
                         stage('Test 4') {
@@ -802,7 +819,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(4, "${WORKER_4_MTR_SUITES}")
+                                doTestWorkerJob(4, "${WORKER_4_MTR_SUITES}")
                             }
                         }
                         stage('Test 5') {
@@ -812,7 +829,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(5, "${WORKER_5_MTR_SUITES}")
+                                doTestWorkerJob(5, "${WORKER_5_MTR_SUITES}")
                             }
                         }
                         stage('Test 6') {
@@ -822,7 +839,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(6, "${WORKER_6_MTR_SUITES}")
+                                doTestWorkerJob(6, "${WORKER_6_MTR_SUITES}")
                             }
                         }
                         stage('Test 7') {
@@ -832,7 +849,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(7, "${WORKER_7_MTR_SUITES}")
+                                doTestWorkerJob(7, "${WORKER_7_MTR_SUITES}")
                             }
                         }
                         stage('Test 8') {
@@ -842,7 +859,7 @@ pipeline {
                             }
                             agent { label LABEL }
                             steps {
-                                doTestWorkerJobWithGuard(8, "${WORKER_8_MTR_SUITES}")
+                                doTestWorkerJob(8, "${WORKER_8_MTR_SUITES}")
                             }
                         }
                     }

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -179,7 +179,7 @@
         description: "MTR workers count for standalone tests"
     - bool:
         name: ALLOW_ABORTED_WORKERS_RERUN
-        default: true
+        default: false
         description: "Rerun aborted workers"
     - string:
         name: SLACK_CHANNEL


### PR DESCRIPTION
1. Fix missing `#!/bin/bash` in `env.COMPILER_VERSION` (PKG-1061)
2. Check if `sources` exists and is a valid git repo with a proper permissions. In case repo is not valid it's removed as it probably comes from a previous run which was not cleaned properly.
3.  `ALLOW_ABORTED_WORKERS_RERUN` was created for spot instances that were killed by AWS. But this option created a side-effect that all pipeline FAILUREs are converted to UNSTABLEs. Fixes:
a) disable `ALLOW_ABORTED_WORKERS_RERUN` by default
b) use `catchError(buildResult: 'UNSTABLE')` only if `ALLOW_ABORTED_WORKERS_RERUN` is enabled
c) add `try {} catch (err)` to print a warning that a worker/agent failed
