### PR TITLE
PS-10081: Create a separate pipeline to start Valgrind jobs on Hetzner

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -115,4 +115,28 @@ docker run --rm --shm-size=32G \
     bash -x /tmp/scripts/test-binary-parallel-mtr /tmp/work/
 
     sudo chown -R $(id -u):$(id -g) /tmp/work/results
-" 2>&1 | tee ${WORK_DIR}/mtr_test.log
+" 2>&1 | tee ${WORK_DIR}/mtr-test_${WORKER_NO}.log
+
+cd $WORK_DIR
+whoami
+ls -l
+
+if [[ "$ANALYZER_OPTS" == *"-DWITH_VALGRIND=ON"* ]]; then
+    mv mtr-test_${WORKER_NO}.log mtr-test_${WORKER_NO}_full.log
+    zstd -c mtr-test_${WORKER_NO}_full.log > mtr-test_${WORKER_NO}_full.log.zst
+
+    source ${SCRIPTS_DIR}/utils.inc.sh
+    filter_valgrind_log mtr-test_${WORKER_NO}_full.log mtr-test_${WORKER_NO}.log
+    rm -rf mtr-test_${WORKER_NO}_full.log
+
+    grep -A16 "Conditional jump or move depends on uninitialised" mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-valgrind-ConditionalJump.log || :
+    grep -A16 "are definitely lost"          mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-valgrind-definitelyLost.log || :
+    grep -B128 -A128 "Invalid read of size"  mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-valgrind-InvalidRead.log || :
+    grep -B128 -A128 "Invalid write of size" mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-valgrind-InvalidWrite.log || :
+fi
+
+if [[ "$ANALYZER_OPTS" == *"-DWITH_ASAN=ON"* ]]; then
+    grep -A16 "ERROR: .*Sanitizer"          mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-Errors-Sanitizers.log || :
+    grep -A16 "ERROR: AddressSanitizer"     mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-Errors-AddressSanitizer.log || :
+    grep -A16 "ERROR: LeakSanitizer"        mtr-test_${WORKER_NO}.log >mtr-test_${WORKER_NO}-Errors-LeakSanitizer.log || :
+fi

--- a/jenkins/jenkins-utils.inc.sh
+++ b/jenkins/jenkins-utils.inc.sh
@@ -65,12 +65,18 @@ function build_and_run_sanitizer() {
     filter_valgrind_log mtr-test.full-log mtr-test.log
     zstd -c mtr-test.log > mtr-test.log.zst
 
-    grep -A16 "Conditional jump or move depends on uninitialised" mtr-test.log >mtr-test-valgrind-ConditionalJump.log || :
-    grep -A16 "are definitely lost"         mtr-test.log >mtr-test-valgrind-definitelyLost.log || :
-    grep -B128 -A128 "Invalid read of size" mtr-test.log >mtr-test-valgrind-InvalidRead.log || :
-    grep -A16 "ERROR: .*Sanitizer"          mtr-test.log >mtr-test-Errors-Sanitizers.log || :
-    grep -A16 "ERROR: AddressSanitizer"     mtr-test.log >mtr-test-Errors-AddressSanitizer.log || :
-    grep -A16 "ERROR: LeakSanitizer"        mtr-test.log >mtr-test-Errors-LeakSanitizer.log || :
+    if [[ "$ANALYZER_OPTS" == *"-DWITH_VALGRIND=ON"* ]]; then
+        grep -A16 "Conditional jump or move depends on uninitialised" mtr-test.log >mtr-test-valgrind-ConditionalJump.log || :
+        grep -A16 "are definitely lost"          mtr-test.log >mtr-test-valgrind-definitelyLost.log || :
+        grep -B128 -A128 "Invalid read of size"  mtr-test.log >mtr-test-valgrind-InvalidRead.log || :
+        grep -B128 -A128 "Invalid write of size" mtr-test.log >mtr-test-valgrind-InvalidWrite.log || :
+    fi
+
+    if [[ "$ANALYZER_OPTS" == *"-DWITH_ASAN=ON"* ]]; then
+        grep -A16 "ERROR: .*Sanitizer"          mtr-test.log >mtr-test-Errors-Sanitizers.log || :
+        grep -A16 "ERROR: AddressSanitizer"     mtr-test.log >mtr-test-Errors-AddressSanitizer.log || :
+        grep -A16 "ERROR: LeakSanitizer"        mtr-test.log >mtr-test-Errors-LeakSanitizer.log || :
+    fi
 
     ls -l
     cp $WORK_DIR/*.log* $WORKSPACE/

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -134,6 +134,7 @@
         choices:
         - "Hetzner"
         - "AWS"
+        - "epyc9654"
         description: "Host provider for Jenkins workers"
     - choice:
         name: FULL_MTR

--- a/jenkins/percona-server-sanitizers-epyc9654-noble.yml
+++ b/jenkins/percona-server-sanitizers-epyc9654-noble.yml
@@ -216,8 +216,9 @@
           keep-long-stdio: true
           health-scale-factor: 1.0
           allow-empty-results: false
+          keep-long-stdio: false
       - archive:
-          artifacts: "*.tar.gz, *.log*, *.txt, *.xml"
+          artifacts: "*.tar.gz, *.log*, *.txt"
           allow_empty_archive: false
           only_if_successful: false
           fingerprint: false
@@ -231,7 +232,7 @@
     name: ASAN-8.0
     sanitizer: ASAN
     ps_version: 8.0
-    branch_name: release-8.0.42-33
+    branch_name: release-8.0.43-34
     sanitizer_opts: '-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON'
     mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --parallel=96
     scripts_repo: Percona-Lab/ps-build
@@ -243,9 +244,9 @@
     name: VALGRIND-8.0
     sanitizer: VALGRIND
     ps_version: 8.0
-    branch_name: release-8.0.42-33
+    branch_name: release-8.0.43-34
     sanitizer_opts: '-DWITH_VALGRIND=ON'
-    mtr_opts: --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
     scripts_repo: Percona-Lab/ps-build
     scripts_branch: 8.0
     jobs:
@@ -256,7 +257,7 @@
     name: ASAN-8.4
     sanitizer: ASAN
     ps_version: 8.4
-    branch_name: release-8.4.5-5
+    branch_name: release-8.4.6-6
     sanitizer_opts: '-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON'
     mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --parallel=96
     scripts_repo: Percona-Lab/ps-build
@@ -268,9 +269,9 @@
     name: VALGRIND-8.4
     sanitizer: VALGRIND
     ps_version: 8.4
-    branch_name: release-8.4.5-5
+    branch_name: release-8.4.6-6
     sanitizer_opts: '-DWITH_VALGRIND=ON'
-    mtr_opts: --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
     scripts_repo: Percona-Lab/ps-build
     scripts_branch: 8.0
     jobs:
@@ -281,7 +282,7 @@
     name: ASAN-9.x
     sanitizer: ASAN
     ps_version: 9.x
-    branch_name: release-9.2.0-1
+    branch_name: release-9.4.0-1
     sanitizer_opts: '-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON'
     mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --parallel=96
     scripts_repo: Percona-Lab/ps-build
@@ -293,9 +294,9 @@
     name: VALGRIND-9.x
     sanitizer: VALGRIND
     ps_version: 9.x
-    branch_name: release-9.2.0-1
+    branch_name: release-9.4.0-1
     sanitizer_opts: '-DWITH_VALGRIND=ON'
-    mtr_opts: --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0 --parallel=64
     scripts_repo: Percona-Lab/ps-build
     scripts_branch: 8.0
     jobs:

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -232,8 +232,13 @@ void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDA
 
             // This is questionable. Do we need result XMLs in S3 cache while Jenkins archives them as well?
             syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')
-            step([$class: 'JUnitResultArchiver', testResults: "${WORK_DIR}/results/*.xml", healthScaleFactor: 1.0])
-            archiveArtifacts "${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
+            step([
+                $class: 'JUnitResultArchiver',
+                testResults: "${WORK_DIR}/results/*.xml",
+                healthScaleFactor: 1.0,
+                keepLongStdio: false
+            ])
+            archiveArtifacts "${WORK_DIR}/*.log*,${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
 
             // cleanup before marking success
             cleanWorkspace(WORKER_ID)
@@ -621,6 +626,9 @@ def notifySlack(status, color, customMessage) {
 
 if (params.CLOUD == 'Hetzner') {
     LABEL = 'docker-x64'
+    MICRO_LABEL = 'launcher-x64'
+} else if (params.CLOUD == 'epyc9654') {
+    LABEL = 'as-1015cs-tnr'
     MICRO_LABEL = 'launcher-x64'
 } else {
     // by default fallback to AWS

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -126,6 +126,7 @@
         choices:
         - "Hetzner"
         - "AWS"
+        - "epyc9654"
         description: "Host provider for Jenkins workers"
     - choice:
         name: FULL_MTR
@@ -259,11 +260,12 @@
     jobs:
       - percona-server-{ps_version}-pipeline-parallel-mtr
 
+
 - project:
-    name: pipeline-parallel-mtr-8.0-valgrind
-    ps_version: 8.0-valgrind
-    branch_name: release-8.0.42-33
-    mtr_opts: --unit-tests-report --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0
+    name: pipeline-parallel-mtr-VALGRIND
+    ps_version: VALGRIND
+    branch_name: release-9.4.0-1
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:

--- a/local/utils.inc.sh
+++ b/local/utils.inc.sh
@@ -13,8 +13,9 @@ function filter_valgrind_log() {
   }
 
   /==[0-9]+== .*in loss record [0-9,]+ of [0-9,]+/ {
-      match($0, /==([0-9]+)== .*in loss record ([0-9,]+) of [0-9,]+/, m)
-      record_num = strip_commas(m[2])  # cleans and converts
+      # Extract the record number
+      n = split($0, parts, /in loss record | of /)
+      record_num = strip_commas(parts[2])
       if (record_num > 16) {
           skipping = 1
       } else {


### PR DESCRIPTION
1. utils.inc.sh: Add support for `mawk` in `filter_valgrind_log()`
2. Improve `percona-server-sanitizers-epyc9654-noble` pipelines
3. Improve `percona-server-VALGRIND-pipeline-parallel-mtr` pipeline:
- add support for `as-1015cs-tnr`
- use `keepLongStdio: false`
- parse Valgrind and ASan logs for errors and output results as artifacts