### PR TITLE
PS-9806 [5.7]: Add support for Hetzner cloud/docker hosts

### DIFF
--- a/docker/run-test
+++ b/docker/run-test
@@ -27,12 +27,12 @@ if [[ "${KEYRING_VAULT_MTR}" == 'yes' ]] && [[ ${DOCKER_OS} != 'centos:6' ]] && 
     BOOTSTRAP_PROD_V1="$(bash $SCRIPTS_DIR/bootstrap-vault --mode=prod --version="${KEYRING_VAULT_V1_VERSION}" --alias=v1 --port="9300")"
     export VAULT_V1_PROD_ROOT_TOKEN=$(echo "$BOOTSTRAP_PROD_V1" | grep "Production token" | awk -F ':' '{print $2}' | xargs)
     export VAULT_V1_PROD_MTR_TOKEN=$(echo "$BOOTSTRAP_PROD_V1" | grep "MTR token" | awk -F ':' '{print $2}' | xargs)
-    sudo install --owner=27 --group=27 /tmp/vault.d-v1-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v1-ca.pem
+    sudo install --owner=1001 --group=1001 /tmp/vault.d-v1-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v1-ca.pem
 
     BOOTSTRAP_PROD_V2="$(bash $SCRIPTS_DIR/bootstrap-vault --mode=prod --version="${KEYRING_VAULT_V2_VERSION}" --alias=v2 --port="9500")"
     export VAULT_V2_PROD_ROOT_TOKEN=$(echo "$BOOTSTRAP_PROD_V2" | grep "Production token" | awk -F ':' '{print $2}' | xargs)
     export VAULT_V2_PROD_MTR_TOKEN=$(echo "$BOOTSTRAP_PROD_V2" | grep "MTR token" | awk -F ':' '{print $2}' | xargs)
-    sudo install --owner=27 --group=27 /tmp/vault.d-v2-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v2-ca.pem
+    sudo install --owner=1001 --group=1001 /tmp/vault.d-v2-prod/ssl/ca.pem $ROOT_DIR/vault-prod-v2-ca.pem
 
     VAULT_DOCKER_FLAG="--network bridge-vault"
 fi

--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -172,11 +172,11 @@
         - "no"
         description: Run case-insensetive MTR tests
     - choice:
-        name: LABEL
+        name: CLOUD
         choices:
-        - docker
-        - docker-32gb
-        description: Run build on specified instance type
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"
     axes:
       - axis:
          type: user-defined

--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -64,8 +64,8 @@
     - choice:
         name: WITH_TOKUDB
         choices:
-        - "ON"
         - "OFF"
+        - "ON"
         description: Compile TokuDB engine
     - choice:
         name: WITH_ROCKSDB

--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -177,6 +177,13 @@
         - "Hetzner"
         - "AWS"
         description: "Host provider for Jenkins workers"
+    - string:
+        name: JENKINS_SCRIPTS_REPO
+        default: 'https://github.com/Percona-Lab/ps-build'
+        description: Download the build scripts from this repository, except for the Groovy script referenced by the path defined in pipeline.yml
+    - string:
+        name: JENKINS_SCRIPTS_BRANCH
+        default: '5.7'
     axes:
       - axis:
          type: user-defined

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -53,7 +53,7 @@ pipeline {
                         fi
                         rm -f ${WORKSPACE}/VERSION-${BUILD_NUMBER}
                     '''
-                    git branch: '5.7', url: 'https://github.com/Percona-Lab/ps-build'
+                    git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
                     sh '''#!/bin/bash -x
                         git reset --hard
                         git clean -xdf
@@ -114,7 +114,7 @@ pipeline {
             options { retry(3) }
             agent { label LABEL }
             steps {
-                git branch: '5.7', url: 'https://github.com/Percona-Lab/ps-build'
+                git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     withCredentials([
                         string(credentialsId: 'MTR_VAULT_TOKEN', variable: 'MTR_VAULT_TOKEN'),

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -143,7 +143,7 @@ pipeline {
                                         sudo dd if=/dev/zero of=/mnt/ci_disk_\$CMAKE_BUILD_TYPE.img bs=1G count=10
                                         sudo /sbin/mkfs.vfat /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img
                                         sudo mkdir -p /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE
-                                        sudo mount -o loop -o uid=27 -o gid=27 -o check=r /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE
+                                        sudo mount -o loop -o uid=1001 -o gid=1001 -o check=r /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE
                                     fi                                
                                 fi
 
@@ -152,7 +152,7 @@ pipeline {
                                 sg docker -c "
                                     if [ \$(docker ps -a -q | wc -l) -ne 0 ]; then
                                         docker ps -a -q | xargs docker stop --time 1 || :
-                                        docker rm --force consul vault-prod-v{1..2} vault-dev-v{1..2} || :
+                                        docker rm --force consul vault-prod-v1 vault-prod-v2 vault-dev-v1 vault-dev-v2 || :
                                     fi
                                     ulimit -a
                                     ./docker/run-test ${DOCKER_OS}

--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -1,154 +1,17 @@
-if (params.MTR_ARGS.contains('--big-test')) {
+AWS_CREDENTIALS_ID = '10ee734d-bbd1-4b4b-a611-5a2765ef9d47'
+
+if (params.CLOUD == 'Hetzner') {
+    LABEL = 'docker-x64'
+    MICRO_LABEL = 'launcher-x64'
+} else {
+    // by default fallback to AWS
     LABEL = 'docker-32gb'
+    MICRO_LABEL = 'micro-amazon'
 }
 
 pipeline {
-    parameters {
-        string(
-            defaultValue: 'https://github.com/percona/percona-server',
-            description: 'URL to percona-server repository',
-            name: 'GIT_REPO',
-            trim: true)
-        string(
-            defaultValue: '5.7',
-            description: 'Tag/Branch for percona-server repository',
-            name: 'BRANCH',
-            trim: true)
-        string(
-            defaultValue: '',
-            description: 'URL to forked PerconaFT repository',
-            name: 'PERCONAFT_REPO',
-            trim: true)
-        string(
-            defaultValue: '',
-            description: 'Tag/Branch for PerconaFT repository',
-            name: 'PERCONAFT_BRANCH',
-            trim: true)
-        string(
-            defaultValue: '',
-            description: 'URL to forked Percona-TokuBackup repository',
-            name: 'TOKUBACKUP_REPO',
-            trim: true)
-        string(
-            defaultValue: '',
-            description: 'Tag/Branch for Percona-TokuBackup repository',
-            name: 'TOKUBACKUP_BRANCH',
-            trim: true)
-        choice(
-            choices: 'centos:7\ncentos:8\noraclelinux:9\nubuntu:bionic\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:buster\ndebian:bullseye\ndebian:bookworm\namazonlinux:2',
-            description: 'OS version for compilation',
-            name: 'DOCKER_OS')
-        choice(
-            choices: '/usr/bin/cmake',
-            description: 'path to cmake binary',
-            name: 'JOB_CMAKE')
-        choice(
-            choices: 'default',
-            description: 'compiler version',
-            name: 'COMPILER')
-        choice(
-            choices: 'RelWithDebInfo\nDebug',
-            description: 'Type of build to produce',
-            name: 'CMAKE_BUILD_TYPE')
-        choice(
-            choices: '\n-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON\n-DWITH_ASAN=ON\n-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON -DWITH_UBSAN=ON\n-DWITH_ASAN=ON -DWITH_UBSAN=ON\n-DWITH_UBSAN=ON\n-DWITH_MSAN=ON\n-DWITH_VALGRIND=ON',
-            description: 'Enable code checking',
-            name: 'ANALYZER_OPTS')
-        choice(
-            choices: 'ON\nOFF',
-            description: 'Compile TokuDB engine',
-            name: 'WITH_TOKUDB')
-        choice(
-            choices: 'ON\nOFF',
-            description: 'Compile RocksDB engine',
-            name: 'WITH_ROCKSDB')
-        choice(
-            choices: 'ON\nOFF',
-            description: 'Whether to build embedded server',
-            name: 'WITH_EMBEDDED_SERVER')
-        choice(
-            choices: 'ON\nOFF',
-            description: 'Whether to build rapid development cycle plugins',
-            name: 'WITH_RAPID')
-        choice(
-            choices: 'system\nbundled',
-            description: 'Type of SSL support',
-            name: 'WITH_SSL')
-        choice(
-            choices: 'ON\nOFF',
-            description: 'Whether to build with support for keyring_vault Plugin',
-            name: 'WITH_KEYRING_VAULT')
-        choice(
-            choices: '\n-DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON',
-            description: 'Disable Performance Schema',
-            name: 'PERFSCHEMA_OPTS')
-        string(
-            defaultValue: '',
-            description: 'cmake options',
-            name: 'CMAKE_OPTS')
-        string(
-            defaultValue: '',
-            description: 'make options, like VERBOSE=1',
-            name: 'MAKE_OPTS')
-
-        choice(
-            choices: 'yes\nno',
-            description: 'Run mysql-test-run.pl',
-            name: 'DEFAULT_TESTING')
-        choice(
-            choices: 'yes\nno',
-            description: 'Run mysql-test-run.pl --suite tokudb.backup',
-            name: 'HOTBACKUP_TESTING')
-        choice(
-            choices: 'yes\nno',
-            description: 'Run mtr --suite=engines/iuds,engines/funcs --mysqld=--default-storage-engine=tokudb',
-            name: 'TOKUDB_ENGINES_MTR')
-        string(
-            defaultValue: '--unit-tests-report',
-            description: 'TokuDB specific mtr args',
-            name: 'TOKUDB_ENGINES_MTR_ARGS')
-        choice(
-            choices: 'yes\nno',
-            description: 'Run mtr --suite=engines/iuds,engines/funcs --mysqld=--default-storage-engine=rocksdb',
-            name: 'ROCKSDB_ENGINES_MTR')
-        string(
-            defaultValue: '--unit-tests-report',
-            description: 'RocksDB specific mtr args',
-            name: 'ROCKSDB_ENGINES_MTR_ARGS')
-
-        string(
-            defaultValue: '--unit-tests-report --big-test',
-            description: 'mysql-test-run.pl options, for options like: --big-test --nounit-tests --unit-tests-report',
-            name: 'MTR_ARGS')
-        string(
-            defaultValue: '1',
-            description: 'Run each test N number of times, --repeat=N',
-            name: 'MTR_REPEAT')
-        choice(
-            choices: 'yes\nno',
-            description: 'Run mtr --suite=keyring_vault',
-            name: 'KEYRING_VAULT_MTR')
-        string(
-            defaultValue: '0.9.6',
-            description: 'Specifies version of Hashicorp Vault for V1 tests',
-            name: 'KEYRING_VAULT_V1_VERSION'
-        )
-        string(
-            defaultValue: '1.9.0',
-            description: 'Specifies version of Hashicorp Vault for V2 tests',
-            name: 'KEYRING_VAULT_V2_VERSION'
-        )
-        choice(
-            choices: 'yes\nno',
-            description: 'Run case-insensetive MTR tests',
-            name: 'CI_FS_MTR')
-        choice(
-            choices: 'docker\ndocker-32gb',
-            description: 'Run build on specified instance type',
-            name: 'LABEL')
-    }
     agent {
-        label 'micro-amazon'
+        label MICRO_LABEL
     }
     options {
         skipDefaultCheckout()
@@ -163,11 +26,11 @@ pipeline {
                 script {
                     currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                 }
-                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '10ee734d-bbd1-4b4b-a611-5a2765ef9d47', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                   withCredentials([string(credentialsId: 'JNKPercona', variable: 'JNKPercona_token')]) {
                     sh 'echo Prepare: \$(date -u "+%s")'
                     echo 'Checking Percona Server branch version, JEN-913 prevent wrong version run'
-                    sh '''
+                    sh '''#!/bin/bash -x
                         MY_BRANCH_BASE_MAJOR=5
                         MY_BRANCH_BASE_MINOR=7
                         GIT_REPO_LINK=${GIT_REPO}
@@ -191,7 +54,7 @@ pipeline {
                         rm -f ${WORKSPACE}/VERSION-${BUILD_NUMBER}
                     '''
                     git branch: '5.7', url: 'https://github.com/Percona-Lab/ps-build'
-                    sh '''
+                    sh '''#!/bin/bash -x
                         git reset --hard
                         git clean -xdf
                         sudo rm -rf sources
@@ -235,13 +98,15 @@ pipeline {
         }
         stage('Archive Build') {
             options { retry(3) }
-            agent { label 'micro-amazon' }
+            agent { label MICRO_LABEL }
             steps {
                 deleteDir()
-                sh '''
-                    aws s3 cp --no-progress s3://ps-build-cache/${BUILD_TAG}/build.log.gz ./build.log.gz
-                    gunzip build.log.gz
-                '''
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                    sh '''
+                        aws s3 cp --no-progress s3://ps-build-cache/${BUILD_TAG}/build.log.gz ./build.log.gz
+                        gunzip build.log.gz
+                    '''
+                }
                 recordIssues enabledForFailure: true, tools: [gcc(pattern: 'build.log')]
             }
         }
@@ -250,12 +115,12 @@ pipeline {
             agent { label LABEL }
             steps {
                 git branch: '5.7', url: 'https://github.com/Percona-Lab/ps-build'
-                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '10ee734d-bbd1-4b4b-a611-5a2765ef9d47', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     withCredentials([
                         string(credentialsId: 'MTR_VAULT_TOKEN', variable: 'MTR_VAULT_TOKEN'),
                         string(credentialsId: 'VAULT_V1_DEV_TOKEN', variable: 'VAULT_V1_DEV_TOKEN'),
                         string(credentialsId: 'VAULT_V2_DEV_TOKEN', variable: 'VAULT_V2_DEV_TOKEN')]) {
-                            sh '''
+                            sh '''#!/bin/bash -x
                                 git reset --hard
                                 git clean -xdf
                                 ls -la ./ || true
@@ -267,7 +132,11 @@ pipeline {
                                     mkdir -p sources/results
                                 done
 
-                                sudo yum -y install jq
+                                if [ -f /usr/bin/yum ]; then
+                                    sudo yum -y install jq
+                                else
+                                    sudo apt-get install -y jq
+                                fi
 
                                 if [[ \$CI_FS_MTR == 'yes' ]]; then
                                     if [[ ! -f /mnt/ci_disk_\$CMAKE_BUILD_TYPE.img ]] && [[ -z \$(mount | grep /mnt/ci_disk_dir_\$CMAKE_BUILD_TYPE) ]]; then
@@ -300,17 +169,19 @@ pipeline {
         }
         stage('Archive') {
             options { retry(3) }
-            agent { label 'micro-amazon' }
+            agent { label MICRO_LABEL }
             steps {
                 deleteDir()
-                sh '''
-                    aws s3 sync --no-progress --exclude 'binary.tar.gz' s3://ps-build-cache/${BUILD_TAG}/ ./
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                    sh '''
+                        aws s3 sync --no-progress --exclude 'binary.tar.gz' s3://ps-build-cache/${BUILD_TAG}/ ./
 
-                    echo "
-                        binary    - https://s3.us-east-2.amazonaws.com/ps-build-cache/${BUILD_TAG}/binary.tar.gz
-                        build log - https://s3.us-east-2.amazonaws.com/ps-build-cache/${BUILD_TAG}/build.log.gz
-                    " > public_url
-                '''
+                        echo "
+                            binary    - https://s3.us-east-2.amazonaws.com/ps-build-cache/${BUILD_TAG}/binary.tar.gz
+                            build log - https://s3.us-east-2.amazonaws.com/ps-build-cache/${BUILD_TAG}/build.log.gz
+                        " > public_url
+                    '''
+                }
                 script {
                     if (!(params.GIT_REPO =~ 'post-eol')) {
                         step([$class: 'JUnitResultArchiver', testResults: '**/*.xml', healthScaleFactor: 1.0])

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -192,8 +192,8 @@
         - "no"
         description: Run case-insensetive MTR tests
     - choice:
-        name: LABEL
+        name: CLOUD
         choices:
-        - docker
-        - docker-32gb
-        description: Run build on specified instance type
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -197,3 +197,10 @@
         - "Hetzner"
         - "AWS"
         description: "Host provider for Jenkins workers"
+    - string:
+        name: JENKINS_SCRIPTS_REPO
+        default: 'https://github.com/Percona-Lab/ps-build'
+        description: Download the build scripts from this repository, except for the Groovy script referenced by the path defined in pipeline.yml
+    - string:
+        name: JENKINS_SCRIPTS_BRANCH
+        default: '5.7'

--- a/jenkins/pipeline.yml
+++ b/jenkins/pipeline.yml
@@ -84,8 +84,8 @@
     - choice:
         name: WITH_TOKUDB
         choices:
-        - "ON"
         - "OFF"
+        - "ON"
         description: Compile TokuDB engine
     - choice:
         name: WITH_ROCKSDB

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -63,8 +63,8 @@
     - choice:
         name: WITH_TOKUDB
         choices:
-        - "OFF"
         - "ON"
+        - "OFF"
         description: Compile TokuDB engine
     - choice:
         name: WITH_ROCKSDB

--- a/local/bootstrap-vault
+++ b/local/bootstrap-vault
@@ -39,12 +39,14 @@ parse_arguments() {
 }
 
 function prepare_consul {
+    docker rm -f consul ||:
     docker run -d --name=consul --hostname=consul --net bridge-vault -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}' hashicorp/consul agent -server -bind=0.0.0.0 -client=0.0.0.0 -alt-domain=consul -retry-join=127.0.0.1 -bootstrap-expect=1
     return
 }
 
 function prepare_prod_env {
     local cluster_addr_port=${1:-}
+    rm -rf /tmp/vault.d-${ALIAS}-prod /tmp/vault.d-${ALIAS}-prod/policies /tmp/vault.d-${ALIAS}-prod/ssl
     mkdir -p /tmp/vault.d-${ALIAS}-prod/ /tmp/vault.d-${ALIAS}-prod/policies /tmp/vault.d-${ALIAS}-prod/ssl
 
     # Generate SSL CA and CRT + KEY for TLS
@@ -54,6 +56,8 @@ function prepare_prod_env {
     openssl req -newkey rsa:2048 -subj "/CN=VAULT CERT" -nodes -keyout /tmp/vault.d-${ALIAS}-prod/ssl/privkey.pem -out /tmp/vault.d-${ALIAS}-prod/ssl/server-req.pem
     openssl x509 -req -in /tmp/vault.d-${ALIAS}-prod/ssl/server-req.pem -days 31 -CA /tmp/vault.d-${ALIAS}-prod/ssl/ca.pem -CAkey /tmp/vault.d-${ALIAS}-prod/ssl/ca.key -set_serial 01 -out /tmp/vault.d-${ALIAS}-prod/ssl/fullchain.pem -extfile /tmp/extfile.cnf
     cat /tmp/vault.d-${ALIAS}-prod/ssl/ca.pem | tee -a /tmp/vault.d-${ALIAS}-prod/ssl/fullchain.pem
+
+    chmod 664 /tmp/vault.d-${ALIAS}-prod/ssl/*
 
     # Place config files
 cat <<-EOF | tee /tmp/vault.d-${ALIAS}-prod/config.hcl
@@ -103,13 +107,25 @@ function main {
             fi
         fi
         prepare_prod_env $(($(echo ${PORT}) + 1))
+
+        # If this Jenkis worker instance is reused by Jenkins, we need to remove
+        # the old vault container before creating the new one.
+        docker rm -f vault-prod-${ALIAS} ||:
+
         docker run --cap-add=IPC_LOCK -d --name=vault-prod-${ALIAS} --hostname=vault-prod-${ALIAS} --net bridge-vault -v /tmp/vault.d-${ALIAS}-prod:/etc/vault.d vault:${VERSION} server -config=/etc/vault.d/config.hcl
         sleep 10
+
+        echo "Vault container started. Logs start >>>"
+        DOCKER_LOGS="$(docker logs -t vault-prod-${ALIAS})"
+        echo ${DOCKER_LOGS}
+        echo "<<< Logs end"
+
         VAULT_PROD_KEYS="$(docker exec -e VAULT_ADDR="https://vault-prod-${ALIAS}:${PORT}" -e VAULT_CACERT="/etc/vault.d/ssl/ca.pem" -t vault-prod-${ALIAS} vault operator init -format=json)"
         VAULT_PROD_UNSEAL_KEYS=$(echo "$VAULT_PROD_KEYS" | jq '.unseal_keys_b64' | awk -F '"' '{print $2}' | xargs)
         VAULT_PROD_TOKEN=$(echo "$VAULT_PROD_KEYS" | jq -r '.root_token')
 
         for key in $VAULT_PROD_UNSEAL_KEYS; do
+            echo "Unseal key $key"
             docker exec -e VAULT_ADDR="https://vault-prod-${ALIAS}:${PORT}" -e VAULT_CACERT="/etc/vault.d/ssl/ca.pem" -t vault-prod-${ALIAS} vault operator unseal "$key"
             sleep 1
         done
@@ -121,6 +137,8 @@ function main {
         echo "MTR token: ${VAULT_MTR_TOKEN}"
     else
         prepare_dev_env
+
+        docker rm -f vault-dev-${ALIAS} ||:
         docker run --cap-add=IPC_LOCK -d --name=vault-dev-${ALIAS} --hostname=vault-dev-${ALIAS} --net bridge-vault -v /tmp/vault.d-${ALIAS}-dev:/etc/vault.d vault:${VERSION} server -dev -dev-listen-address=vault-dev-${ALIAS}:${PORT} -dev-root-token-id=${DEVTOKEN}
         sleep 3
         docker exec -e VAULT_TOKEN=${DEVTOKEN} -e VAULT_ADDR="http://vault-dev-${ALIAS}:${PORT}" -t vault-dev-${ALIAS} vault policy write mtr /etc/vault.d/policies/mtr.hcl


### PR DESCRIPTION
1. Remove `pipeline.parameters` as they are duplicated with YML files.
2. Backport support for Hetzner cloud/docker hosts from 8.0.
3. Backport `local/bootstrap-vault` from 8.0.
4. Add support for `JENKINS_SCRIPTS_REPO` and `JENKINS_SCRIPTS_BRANCH` params.
5. Add support for Debian-based distros which use `dash` as default `/bin/sh`.
6. Change default value of `WITH_TOKUDB` to `OFF`.