### PR TITLE
PS-10105: Support building and running test suite for JS Stored Routi…

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -50,6 +50,7 @@ docker run --rm \
     export WITH_ROUTER='${WITH_ROUTER}'
     export WITH_GCOV='${WITH_GCOV}'
     export WITH_MYSQLX='${WITH_MYSQLX}'
+    export WITH_JS_LANG='${WITH_JS_LANG}'
     export CMAKE_OPTS='${CMAKE_OPTS}'
     export MAKE_OPTS='${MAKE_OPTS}'
     export BUILD_COMMENT='${BUILD_COMMENT}'

--- a/docker/run-build-debug
+++ b/docker/run-build-debug
@@ -44,6 +44,7 @@ docker run -it --rm \
     export WITH_ROUTER='${WITH_ROUTER}'
     export WITH_GCOV='${WITH_GCOV}'
     export WITH_MYSQLX='${WITH_MYSQLX}'
+    export WITH_JS_LANG='${WITH_JS_LANG}'
     export CMAKE_OPTS='${CMAKE_OPTS}'
     export MAKE_OPTS='${MAKE_OPTS}'
     export BUILD_COMMENT='${BUILD_COMMENT}'

--- a/jenkins/jenkins-utils.inc.sh
+++ b/jenkins/jenkins-utils.inc.sh
@@ -8,8 +8,8 @@
 #      PS_BUILD_BRANCH - branch for ps-build repo e.g. "8.0"
 #      SKIP_BUILD = (yes no) - skip building a server from sources and use last build for a given PS_BUILD_BRANCH
 #      GIT_REPO, BRANCH - used by ./local/checkout
-#      JOB_CMAKE, COMPILER, CMAKE_BUILD_TYPE, WITH_ROCKSDB, WITH_ROUTER, WITH_GCOV, WITH_MYSQLX, ANALYZER_OPTS,
-#                        MAKE_OPTS, CMAKE_OPTS - used by local/build-binary
+#      JOB_CMAKE, COMPILER, CMAKE_BUILD_TYPE, WITH_ROCKSDB, WITH_ROUTER, WITH_GCOV, WITH_MYSQLX, WITH_JS_LANG,
+#                        ANALYZER_OPTS, MAKE_OPTS, CMAKE_OPTS - used by local/build-binary
 #      CMAKE_BUILD_TYPE, KEEP_BUILD, ANALYZER_OPTS, MTR_ARGS, MTR_REPEAT, MTR_SUITES, WORKER_NO, DOCKER_OS, CI_FS_MTR,
 #                        WITH_PS_PROTOCOL, KEYRING_VAULT_MTR, WITH_ROCKSDB - used by local/test-binary-parallel-mtr
 

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -80,6 +80,12 @@
         - "ON"
         - "OFF"
         description: Whether to build with support for X Plugin
+    - choice:
+        name: WITH_JS_LANG
+        choices:
+        - "OFF"
+        - "ON"
+        description: Whether to build JS Stored Programs component
     - string:
         name: CMAKE_OPTS
         default:

--- a/jenkins/percona-server-sanitizers-epyc9654-noble.yml
+++ b/jenkins/percona-server-sanitizers-epyc9654-noble.yml
@@ -69,6 +69,12 @@
         - "ON"
         - "OFF"
         description: Whether to build with support for X Plugin
+    - choice:
+        name: WITH_JS_LANG
+        choices:
+        - "OFF"
+        - "ON"
+        description: Whether to build JS Stored Programs component
     - string:
         name: CMAKE_OPTS
         default: "-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DROCKSDB_DISABLE_MARCH_NATIVE=1"
@@ -182,6 +188,7 @@
             echo WITH_ROCKSDB=$WITH_ROCKSDB
             echo WITH_ROUTER=$WITH_ROUTER
             echo WITH_MYSQLX=$WITH_MYSQLX
+            echo WITH_JS_LANG=$WITH_JS_LANG
             echo CMAKE_OPTS=$CMAKE_OPTS
             echo MAKE_OPTS=$MAKE_OPTS
             echo CI_FS_MTR=$CI_FS_MTR

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -456,6 +456,7 @@ void triggerAbortedTestWorkersRerun() {
                             string(name:'WITH_ROCKSDB', value: env.WITH_ROCKSDB),
                             string(name:'WITH_ROUTER', value: env.WITH_ROUTER),
                             string(name:'WITH_MYSQLX', value: env.WITH_MYSQLX),
+                            string(name:'WITH_JS_LANG', value: env.WITH_JS_LANG),
                     string(name:'CMAKE_OPTS', value: env.CMAKE_OPTS),
                     string(name:'MAKE_OPTS', value: env.MAKE_OPTS),
                     string(name:'MTR_ARGS', value: env.MTR_ARGS),

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -79,6 +79,12 @@
         - "ON"
         - "OFF"
         description: Whether to build with support for X Plugin
+    - choice:
+        name: WITH_JS_LANG
+        choices:
+        - "OFF"
+        - "ON"
+        description: Whether to build JS Stored Programs component
     - string:
         name: CMAKE_OPTS
         default:

--- a/local/build-binary
+++ b/local/build-binary
@@ -14,6 +14,7 @@ WITH_ROCKSDB=${WITH_ROCKSDB:-ON}
 WITH_ROUTER=${WITH_ROUTER:-ON}
 WITH_GCOV=${WITH_GCOV:-OFF}
 WITH_MYSQLX=${WITH_MYSQLX:-ON}
+WITH_JS_LANG=${WITH_JS_LANG:-OFF}
 ANALYZER_OPTS=${ANALYZER_OPTS:-}
 MAKE_OPTS=${MAKE_OPTS:--j$(grep -c ^processor /proc/cpuinfo)}
 CMAKE_OPTS=${CMAKE_OPTS:-}
@@ -168,6 +169,18 @@ else
 fi
 
 # ------------------------------------------------------------------------------
+# Get prebuilt V8 if we are building with JS Stored Programs support
+# ------------------------------------------------------------------------------
+if [[ ${WITH_JS_LANG} == 'ON' ]]; then
+    V8_VERSION=$(grep 'SET(EXPECTED_V8_VERSION' ${SOURCEDIR}/cmake/v8.cmake | sed -re 's/.*"([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+    pushd ${DOWNLOAD_DIR}
+        wget --progress=dot:giga https://downloads.percona.com/downloads/packaging/v8_${V8_VERSION}.tar.gz
+        tar -xzf v8_${V8_VERSION}.tar.gz
+        rm -rf v8_${V8_VERSION}.tar.gz
+    popd
+fi
+
+# ------------------------------------------------------------------------------
 # Finaly, compile!
 # ------------------------------------------------------------------------------
 pushd ${BUILD_DIR}
@@ -177,6 +190,9 @@ pushd ${BUILD_DIR}
         -DWITH_ROCKSDB=${WITH_ROCKSDB} \
         -DWITH_ROUTER=${WITH_ROUTER} \
         -DWITH_MYSQLX=${WITH_MYSQLX} \
+        -DWITH_JS_LANG=${WITH_JS_LANG} \
+        -DV8_INCLUDE_DIR=${DOWNLOAD_DIR}/v8/include \
+        -DV8_LIB_DIR=${DOWNLOAD_DIR}/v8/out.gn/static/obj \
         -DWITH_MECAB=${WITH_MECAB} \
         -DENABLE_GCOV=${WITH_GCOV} \
         -DWITH_PACKAGE_FLAGS=OFF \


### PR DESCRIPTION
…nes in Jenkins (part 1)

https://perconadev.atlassian.net/browse/PS-10105

Add support for building Percona Server with JS Stored Programs component.

Such build can be enabled by turning ON newly introduced WITH_JS_LANG Jenkins parameter (which is OFF by default). To support this build scripts were modified to automatically download and use appropriate version of V8 engine static library and headers.

Note that we don't enable running component_js_lang test suite by default yet.