### PR TITLE
PS-10120 [5.7]: Fix failing `param` pipeline because of lack of `sudo` permissions

### DIFF
--- a/jenkins/asan-param.yml
+++ b/jenkins/asan-param.yml
@@ -176,7 +176,10 @@
           unstable-threshold: never
           failure-threshold: FAILURE
     - shell: |
-        sudo find . -name "*.xml" -o -name "*.log" -delete
+        whoami
+        ls -l
+        sudo find . \( -name "*.xml" -o -name "*.log" \) -delete || echo "sudo cleanup skipped"
+        find . \( -name "*.xml" -o -name "*.log" \) -delete || echo "cleanup skipped"
     - copyartifact:
         project: percona-server-5.7-pipeline
         which-build: specific-build

--- a/jenkins/param.yml
+++ b/jenkins/param.yml
@@ -218,7 +218,10 @@
           unstable-threshold: never
           failure-threshold: FAILURE
     - shell: |
-        sudo find . -name "*.xml" -o -name "*.log" -delete
+        whoami
+        ls -l
+        sudo find . \( -name "*.xml" -o -name "*.log" \) -delete || echo "sudo cleanup skipped"
+        find . \( -name "*.xml" -o -name "*.log" \) -delete || echo "cleanup skipped"
     - copyartifact:
         project: percona-server-5.7-pipeline
         which-build: specific-build

--- a/jenkins/valgrind-param.yml
+++ b/jenkins/valgrind-param.yml
@@ -182,7 +182,10 @@
           unstable-threshold: never
           failure-threshold: FAILURE
     - shell: |
-        sudo find . -name "*.xml" -o -name "*.log" -delete
+        whoami
+        ls -l
+        sudo find . \( -name "*.xml" -o -name "*.log" \) -delete || echo "sudo cleanup skipped"
+        find . \( -name "*.xml" -o -name "*.log" \) -delete || echo "cleanup skipped"
     - copyartifact:
         project: percona-server-5.7-pipeline
         which-build: specific-build


### PR DESCRIPTION
This is just a workaround but the job doesn't fail anymore.
We also add missing parenthesis for `-name "*.xml" -o -name "*.log"`.
