### PR TITLE
PS-10105: Support building and running test suite for JS Stored Routi…

### DIFF
--- a/local/build-binary
+++ b/local/build-binary
@@ -173,10 +173,16 @@ fi
 # ------------------------------------------------------------------------------
 if [[ ${WITH_JS_LANG} == 'ON' ]]; then
     V8_VERSION=$(grep 'SET(EXPECTED_V8_VERSION' ${SOURCEDIR}/cmake/v8.cmake | sed -re 's/.*"([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+    if [[ "${DOCKER_OS}" == "centos-8" ]] || [[ "${DOCKER_OS}" == "debian-bullseye" ]] || [[ "${DOCKER_OS}" == "ubuntu-focal" ]]; then
+      # Platforms with older glibc need V8 built against older glibc as well.
+      V8_ARCHIVE_NAME=v8_${V8_VERSION}-glibc2.31
+    else
+      V8_ARCHIVE_NAME=v8_${V8_VERSION}
+    fi
     pushd ${DOWNLOAD_DIR}
-        wget --progress=dot:giga https://downloads.percona.com/downloads/packaging/v8_${V8_VERSION}.tar.gz
-        tar -xzf v8_${V8_VERSION}.tar.gz
-        rm -rf v8_${V8_VERSION}.tar.gz
+        wget --progress=dot:giga https://downloads.percona.com/downloads/packaging/${V8_ARCHIVE_NAME}.tar.gz
+        tar -xzf ${V8_ARCHIVE_NAME}.tar.gz
+        rm -rf ${V8_ARCHIVE_NAME}.tar.gz
     popd
 fi
 


### PR DESCRIPTION
…nes in Jenkins (follow-up)

https://perconadev.atlassian.net/browse/PS-10105

Fix failure to load component_js_lang component on CentOS 8, Ubuntu Focal and Debian Bullseye.

The problem with missing "__libc_single_threaded" symbol occurred because V8 used by the component
was built against newer glibc version than those used by these platforms (all of them use glibc versions
prior to version 2.32, where this symbol was introduced).

Use V8 version built against older glibc version on platforms which require this.