### PR TITLE
PS-10223: Add ARM platforms to Jenkins

### DIFF
--- a/docker/prepare-docker
+++ b/docker/prepare-docker
@@ -7,20 +7,24 @@ DOCKER_DIR=$(dirname $0)
 
 build_docker() {
     local SOURCE_IMAGE=$1
+    local ARCH_SUFFIX=""
+    if [[ $(uname -m) == "aarch64" ]]; then
+      ARCH_SUFFIX="-aarch64"
+    fi
 
     sed -e "s^FROM .*^FROM ${SOURCE_IMAGE}^" \
         ${DOCKER_DIR}/Dockerfile.inc \
-        > ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-}
+        > ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-}${ARCH_SUFFIX}
 
     export DOCKER_BUILDKIT=0
     docker build \
         --squash \
         --no-cache \
-        -t public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE//[:\/]/-} \
-        --file ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-} \
+        -t public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE//[:\/]/-}${ARCH_SUFFIX} \
+        --file ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-}${ARCH_SUFFIX} \
         $DOCKER_DIR
 
-    rm ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-}
+    rm ${DOCKER_DIR}/Dockerfile-${SOURCE_IMAGE//[:\/]/-}${ARCH_SUFFIX}
 }
 
 build_docker ${1:-centos:7}

--- a/docker/run-build
+++ b/docker/run-build
@@ -20,6 +20,11 @@ KEEP_BUILD=${KEEP_BUILD:-no}
 DOCKER_OS=${1:-ubuntu:jammy}
 SOURCE_IMAGE=${DOCKER_OS//:/-}
 
+ARCH_SUFFIX=""
+if [[ $(uname -m) == "aarch64" ]]; then
+  ARCH_SUFFIX="-aarch64"
+fi
+
 ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)
 SCRIPTS_DIR=$ROOT_DIR/local
 SOURCES_DIR=$ROOT_DIR/sources
@@ -37,7 +42,7 @@ docker run --rm \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
     --mount type=bind,source=${WORK_DIR},destination=/tmp/work \
     --mount type=bind,source=${ROOT_DIR}/.ccache,destination=/tmp/ccache \
-    public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE} \
+    public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE}${ARCH_SUFFIX} \
     sh -c "
     set -o errexit
     set -o xtrace

--- a/docker/run-build-debug
+++ b/docker/run-build-debug
@@ -19,6 +19,11 @@ KEEP_BUILD=${KEEP_BUILD:-no}
 DOCKER_OS=${1:-ubuntu:jammy}
 SOURCE_IMAGE=${DOCKER_OS//:/-}
 
+ARCH_SUFFIX=""
+if [[ $(uname -m) == "aarch64" ]]; then
+  ARCH_SUFFIX="-aarch64"
+fi
+
 ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)
 SCRIPTS_DIR=$ROOT_DIR/local
 SOURCES_DIR=$ROOT_DIR/sources
@@ -32,7 +37,7 @@ docker run -it --rm \
     --mount type=bind,source=${SOURCES_DIR},destination=/tmp/sources \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
     --mount type=bind,source=${WORK_DIR},destination=/tmp/work \
-    public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE} \
+    public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE}${ARCH_SUFFIX} \
     sh -c "
     set -o errexit
 

--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -21,6 +21,11 @@ DOCKER_OS=${1:-ubuntu:jammy}
 SOURCE_IMAGE=${DOCKER_OS//:/-}
 WORKER_NO=${2:-0}
 
+ARCH_SUFFIX=""
+if [[ $(uname -m) == "aarch64" ]]; then
+  ARCH_SUFFIX="-aarch64"
+fi
+
 ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)
 SCRIPTS_DIR=$ROOT_DIR/local
 # SOURCES_DIR is only required by an original build in ${WORK_DIR}/build to run unit tests
@@ -77,7 +82,7 @@ docker run --rm --shm-size=32G \
     --mount type=bind,source=${WORK_DIR},destination=/tmp/work \
     ${CI_FS_DOCKER_FLAG} \
     ${VAULT_DOCKER_FLAG} \
-    public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE} \
+    public.ecr.aws/e7j3v3n0/ps-build:${SOURCE_IMAGE}${ARCH_SUFFIX} \
     sh -c "
     set -o errexit
     set -o xtrace

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -25,7 +25,7 @@
     - matrix-combinations:
         name: COMBINATIONS
         description: "Select matrix combinations"
-        filter: CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:noble" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:noble" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:bookworm" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:bookworm" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:9" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:9"
+        filter: CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64"
     - string:
         name: GIT_REPO
         default: "https://github.com/percona/percona-server"
@@ -218,6 +218,12 @@
          type: user-defined
          name: DOCKER_OS
          values: '{docker_os_list}'
+      - axis:
+         type: user-defined
+         name: ARCH
+         values:
+          - "x86_64"
+          - "aarch64"
     wrappers:
       - build-user-vars  # Ensures BUILD_USER_ID is available
     builders:
@@ -226,6 +232,7 @@
         current-parameters: true
         predefined-parameters: |
           DOCKER_OS=${{DOCKER_OS}}
+          ARCH=${{ARCH}}
           CMAKE_BUILD_TYPE=${{CMAKE_BUILD_TYPE}}
           LAUNCHER_USER_ID=$BUILD_USER_ID
         block: true

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -471,6 +471,7 @@ void triggerAbortedTestWorkersRerun() {
                     string(name:'GIT_REPO', value: env.GIT_REPO),
                     string(name:'BRANCH', value: env.BRANCH),
                     string(name:'DOCKER_OS', value: env.DOCKER_OS),
+                    string(name:'ARCH', value: env.ARCH),
                     string(name:'JOB_CMAKE', value: env.JOB_CMAKE),
                     string(name:'COMPILER', value: env.COMPILER),
                     string(name:'CMAKE_BUILD_TYPE', value: env.CMAKE_BUILD_TYPE),
@@ -626,14 +627,14 @@ def notifySlack(status, color, customMessage) {
 }
 
 if (params.CLOUD == 'Hetzner') {
-    LABEL = 'docker-x64'
+    LABEL = (params.ARCH == 'aarch64') ? 'docker-aarch64' : 'docker-x64'
     MICRO_LABEL = 'launcher-x64'
 } else if (params.CLOUD == 'epyc9654') {
     LABEL = 'as-1015cs-tnr'
     MICRO_LABEL = 'launcher-x64'
 } else {
     // by default fallback to AWS
-    LABEL = 'docker-32gb'
+    LABEL = (params.ARCH == 'aarch64') ? 'docker-32gb-aarch64' : 'docker-32gb'
     MICRO_LABEL = 'micro-amazon'
 }
 
@@ -666,7 +667,7 @@ pipeline {
                         BUILD_TRIGGER_BY = ' '
                     }
 
-                    currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}${BUILD_TRIGGER_BY} ${CUSTOM_BUILD_NAME}"
+                    currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}/${ARCH}${BUILD_TRIGGER_BY} ${CUSTOM_BUILD_NAME}"
                 }
 
                 sh 'echo Prepare: \$(date -u "+%s")'
@@ -750,7 +751,7 @@ pipeline {
                             buildParamsType: env.BUILD_PARAMS_TYPE,
                             cloud: params.CLOUD,
                             cmakeBuildType: env.CMAKE_BUILD_TYPE,
-                            dockerOs: env.DOCKER_OS,
+                            dockerOs: (env.ARCH == 'aarch64') ? env.DOCKER_OS + '-aarch64' : env.DOCKER_OS,
                             forceCacheMiss: env.FORCE_CACHE_MISS == 'true',
                             serverVersion: SERVER_VERSION,
                             s3Bucket: S3_ROOT_DIR + '/',
@@ -772,7 +773,7 @@ pipeline {
                                 cacheRetentionDays: retentionDays,
                                 cloud: params.CLOUD,
                                 cmakeBuildType: env.CMAKE_BUILD_TYPE,
-                                dockerOs: env.DOCKER_OS,
+                                dockerOs: (env.ARCH == 'aarch64') ? env.DOCKER_OS + '-aarch64' : env.DOCKER_OS,
                                 serverVersion: SERVER_VERSION,
                                 s3Bucket: S3_ROOT_DIR + '/',
                                 toolset: env.TOOLSET,

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -44,6 +44,12 @@
         choices: '{docker_os_list}'
         description: OS version for compilation
     - choice:
+        name: ARCH
+        choices:
+        - "x86_64"
+        - "aarch64"
+        description: CPU architecture for compilation
+    - choice:
         name: CMAKE_BUILD_TYPE
         choices:
         - Debug

--- a/jenkins/prepare-ps-build-docker.groovy
+++ b/jenkins/prepare-ps-build-docker.groovy
@@ -1,0 +1,51 @@
+void build(String SOURCE_IMAGE) {
+  def ARCH_SUFFIX = params.ARCH == "aarch64" ? "-aarch64" : "";
+  sh """
+      sg docker -c "
+          ./docker/prepare-docker ${SOURCE_IMAGE}
+      "
+  """
+  withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'ECRRWUser', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+      sh """
+          SOURCE_IMAGE=${SOURCE_IMAGE}
+          aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
+          sg docker -c "
+              docker push public.ecr.aws/e7j3v3n0/ps-build:\${SOURCE_IMAGE//[:\\/]/-}${ARCH_SUFFIX}
+          "
+      """
+   }
+}
+
+pipeline {
+    agent {
+        label params.ARCH == 'aarch64' ? 'docker-32gb-aarch64' : 'docker-32gb'
+    }
+    options {
+        skipStagesAfterUnstable()
+        buildDiscarder(logRotator(artifactNumToKeepStr: '10'))
+    }
+    stages {
+        stage('Prepare') {
+            steps {
+                git poll: true, branch: '8.0', url: 'https://github.com/Percona-Lab/ps-build'
+                sh '''
+                   git reset --hard
+                   git clean -xdf
+                '''
+            }
+        }
+        stage('Build') {
+            steps {
+                parallel(
+                    "centos:8":        { build('centos:8') },
+                    "oraclelinux:9":   { build('oraclelinux:9') },
+                    "ubuntu:focal":    { build('ubuntu:focal') },
+                    "ubuntu:jammy":    { build('ubuntu:jammy') },
+                    "ubuntu:noble":    { build('ubuntu:noble') },
+                    "debian:bullseye": { build('debian:bullseye') },
+                    "debian:bookworm": { build('debian:bookworm') },
+                )
+            }
+        }
+    }
+}

--- a/jenkins/prepare-ps-build-docker.yml
+++ b/jenkins/prepare-ps-build-docker.yml
@@ -7,59 +7,25 @@
         Do not edit this job through the web!
     disabled: false
     concurrent: false
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/ps-build.git
+            branches:
+            - '8.0'
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: jenkins/prepare-ps-build-docker.groovy
     properties:
     - build-discarder:
         days-to-keep: -1
         num-to-keep: 10
         artifact-days-to-keep: -1
         artifact-num-to-keep: 10
-    dsl: |
-        void build(String SOURCE_IMAGE) {
-            sh """
-                sg docker -c "
-                    ./docker/prepare-docker ${SOURCE_IMAGE}
-                "
-            """
-            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'ECRRWUser', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                sh """
-                    SOURCE_IMAGE=${SOURCE_IMAGE}
-                    aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
-                    sg docker -c "
-                        docker push public.ecr.aws/e7j3v3n0/ps-build:\${SOURCE_IMAGE//[:\\/]/-}
-                    "
-                """
-            }
-        }
-        pipeline {
-            agent {
-                label 'docker-32gb'
-            }
-            options {
-                skipStagesAfterUnstable()
-                buildDiscarder(logRotator(artifactNumToKeepStr: '10'))
-            }
-            stages {
-                stage('Prepare') {
-                    steps {
-                        git poll: true, branch: '8.0', url: 'https://github.com/Percona-Lab/ps-build'
-                        sh '''
-                            git reset --hard
-                            git clean -xdf
-                        '''
-                    }
-                }
-                stage('Build') {
-                    steps {
-                        parallel(
-                            "centos:8":        { build('centos:8') },
-                            "oraclelinux:9":   { build('oraclelinux:9') },
-                            "ubuntu:focal":    { build('ubuntu:focal') },
-                            "ubuntu:jammy":    { build('ubuntu:jammy') },
-                            "ubuntu:noble":    { build('ubuntu:noble') },
-                            "debian:bullseye": { build('debian:bullseye') },
-                            "debian:bookworm": { build('debian:bookworm') },
-                        )
-                    }
-                }
-            }
-        }
+    parameters:
+    - choice:
+        name: ARCH
+        choices:
+        - "x86_64"
+        - "aarch64"
+        description: CPU architecture for images


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-10223

Extended prepare-ps-build-docker pipeline and supporting script so it can now prepare ps-build docker images, which are used for PS build and test runs in Jenkins, for ARM64 platform.

These images are uploaded to ECR with -aarch64 suffix in their tag so they can be correctly identified when used from pipeline-parallel-mtr-*.* pipelines.

Added new ARCH parameter to pipeline-parallel-mtr-*.* pipelines, which allows to choose whether we want to build and test on x86_64 (default) or aarch64 (ARM64) architecture. Adjusted scripts for building server and running tests to take this parameter/the fact that they can be run on ARM64 into account.

Added new ARCH axis to matrix parameter of param-parallel-mtr-*.* job. Combinations using aarch64 (ARM64) architecture are not enabled by default.