### PR TITLE
PS-10081: Misc improvements

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -114,6 +114,7 @@ docker run --rm --shm-size=32G \
 
     bash -x /tmp/scripts/test-binary-parallel-mtr /tmp/work/
 
+    sudo chown $(id -u):$(id -g) /tmp/work
     sudo chown -R $(id -u):$(id -g) /tmp/work/results
 " 2>&1 | tee ${WORK_DIR}/mtr-test_${WORKER_NO}.log
 

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -280,7 +280,7 @@
     name: param-parallel-mtr-8.0
     ps_version: 8.0
     ps_version_no_dot: '8_0'
-    branch_name: release-8.0.42-33
+    branch_name: release-8.0.43-34
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
@@ -298,7 +298,7 @@
     name: param-parallel-mtr-8.x
     ps_version: 8.x
     ps_version_no_dot: '8_x'
-    branch_name: release-8.4.5-5
+    branch_name: release-8.4.6-6
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
@@ -316,7 +316,7 @@
     name: param-parallel-mtr-9.x
     ps_version: 9.x
     ps_version_no_dot: '9_x'
-    branch_name: release-9.2.0-1
+    branch_name: release-9.4.0-1
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -112,7 +112,7 @@ void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
                     else
                         sudo git -C sources log --oneline -10
                         sudo git -C sources reset --hard
-                        sudo git -C sources clean -xdf
+                        sudo git -C sources clean -xdf -e . || :
                         sudo git -C sources submodule update --init || :
                     fi
                 else
@@ -120,7 +120,7 @@ void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
                 fi
             else
                 # "git clean" doesn't remove "sources/" because of ".gitignore"
-                sudo git clean -xdf
+                sudo git clean -xdf || :
                 sudo rm -rf sources
             fi
 
@@ -137,7 +137,7 @@ void cleanWorkspace(Integer WORKER_ID) {
     echo "[INFO] Worker ${WORKER_ID}: cleaning up workspace."
     sh """
         # "git clean" doesn't remove "sources/" because of ".gitignore"
-        sudo git clean -xdf
+        sudo git clean -xdf || :
         sudo rm -rf sources
     """
 }
@@ -281,7 +281,7 @@ void checkoutSources() {
         # sudo is needed for better node recovery after compilation failure
         # if building failed on compilation stage directory will have files owned by docker user
         sudo git reset --hard
-        sudo git clean -xdf
+        sudo git clean -xdf || :
         sudo rm -rf sources
         ./local/checkout
     '''

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -229,6 +229,7 @@ void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDA
             }
 
             echo "[INFO] Worker ${WORKER_ID} finished MTR testing."
+            archiveArtifacts "${WORK_DIR}/*.log*,${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
 
             // This is questionable. Do we need result XMLs in S3 cache while Jenkins archives them as well?
             syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')
@@ -238,7 +239,6 @@ void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDA
                 healthScaleFactor: 1.0,
                 keepLongStdio: false
             ])
-            archiveArtifacts "${WORK_DIR}/*.log*,${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
 
             // cleanup before marking success
             cleanWorkspace(WORKER_ID)

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -565,14 +565,6 @@ if (params.ANALYZER_OPTS.contains('-DWITH_VALGRIND=ON')) {
     PIPELINE_TIMEOUT = 144
 }
 
-if ( ((params.ANALYZER_OPTS.contains('-DWITH_ASAN=ON')) &&
-     (params.ANALYZER_OPTS.contains('-DWITH_ASAN_SCOPE=ON')) &&
-     (params.ANALYZER_OPTS.contains('-DWITH_UBSAN=ON'))) ||
-     ((params.MTR_ARGS.contains('--big-test')) || (params.MTR_ARGS.contains('--only-big-test'))) ) {
-    LABEL = 'docker-32gb'
-    PIPELINE_TIMEOUT = 20
-     }
-
 @NonCPS
 def fetchSlackUserId(email) {
     try {

--- a/local/checkout
+++ b/local/checkout
@@ -17,19 +17,23 @@ pushd $ROOT_DIR
 
     if [ -n "${GIT_REPO}" ]; then
         git remote set-url origin "${GIT_REPO}"
-        git fetch --all
+        git fetch --all --tags
     fi
 
     git reset --hard
     git clean -xdf
 
     if [ -n "${BRANCH}" ]; then
+        git fetch --all --tags
         git checkout "${BRANCH}"
-    fi
-    if [ -n "${GIT_REPO}" -a -n "${BRANCH}" ]; then
-        git pull origin ${BRANCH}
+
+        # If BRANCH is actually a branch (not a tag or commit hash),
+        # make sure it matches the remote exactly (force-push safe)
+        if git rev-parse --abbrev-ref HEAD | grep -qv HEAD; then
+            git reset --hard "origin/${BRANCH}" || true
+        fi
     fi
 
-# update to the pinned revisions
+    # update to the pinned revisions
     git submodule update --init
 popd


### PR DESCRIPTION
1. Restore file permissions in `docker/run-test-parallel-mtr`
2. Update default branch names (8.0.43, 8.4.6, 9.4.0) in `jenkins/param-parallel-mtr.yml`
3. Remove wrong `PIPELINE_TIMEOUT` for `--big-test` in `pipeline-parallel-mtr.groovy`
4. Support `force-push` branches in `local/checkout`:
 - `${BRANCH}` works now for branch names, tags, and commit hashes
 - Make script safe even after `git push --force`.
5. Suppress issues with `git clean -xdf`
6. Move `archiveArtifacts` before `syncDirToS3` for `pipeline-parallel-mtr.groovy` -> It helps in case when `syncDirToS3` fails because XML file is too big.