### PR TITLE
PS-10188: Introduce `EXECUTE_SUITES_ONE_BY_ONE` parameter

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -16,6 +16,7 @@ set -o xtrace
 
 # decides if keep original build files or just ".tar.gz" archive
 KEEP_BUILD=${KEEP_BUILD:-no}
+EXECUTE_SUITES_ONE_BY_ONE=${EXECUTE_SUITES_ONE_BY_ONE:-no}
 
 DOCKER_OS=${1:-ubuntu:jammy}
 SOURCE_IMAGE=${DOCKER_OS//:/-}
@@ -108,6 +109,7 @@ docker run --rm --shm-size=32G \
     export DOCKER_OS='${SOURCE_IMAGE}'
     export WITH_ROCKSDB='${WITH_ROCKSDB}'
     export KEEP_BUILD='${KEEP_BUILD}'
+    export EXECUTE_SUITES_ONE_BY_ONE='${EXECUTE_SUITES_ONE_BY_ONE}'
 
     sudo chown mysql:mysql /tmp/work
     sudo chown -R mysql:mysql /tmp/work/results || :

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -152,6 +152,12 @@
             yes - full MTR<br>
             no - run mtr suites based on variables WORKER_N_MTR_SUITES<br>
             skip_mtr - skip testing phase. Only build.
+    - choice:
+        name: EXECUTE_SUITES_ONE_BY_ONE
+        choices:
+        - "no"
+        - "yes"
+        description: Run each MTR suite separately or run MTR tests merged into 2 groups (normal and big tests) for each worker
     - string:
         name: WORKER_1_MTR_SUITES
         default: ""

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -144,6 +144,12 @@
             yes - full MTR<br>
             no - run mtr suites based on variables WORKER_N_MTR_SUITES<br>
             skip_mtr - skip testing phase. Only build.
+    - choice:
+        name: EXECUTE_SUITES_ONE_BY_ONE
+        choices:
+        - "no"
+        - "yes"
+        description: Run each MTR suite separately or run MTR tests merged into 2 groups (normal and big tests) for each worker
     - string:
         name: WORKER_1_MTR_SUITES
         default: ""

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -92,7 +92,7 @@ function executeSuites() {
     IFS=',' read -ra suiteList <<< "$suites"
     for suite in "${suiteList[@]}"; do
       echo "Executing suite: $suite"
-      execute "$suite" "$parallel" "$extraOptions" "_${suite}${extraSuffix}"
+      execute "$suite" "$parallel" "$extraOptions" ".${suite}${extraSuffix}"
     done
   fi
 }
@@ -274,7 +274,7 @@ if [[ $UNIT_TESTS == "1" ]]; then
         --force \
         --max-test-fail=0 \
         --junit-output=${RESULTS_DIR}/junit_${suiteNoSlash}.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.${suiteNoSlash}" || true
     popd
 
     ln -s ${BUILD_DIR}/mysql-test/var $PWD/var_${suiteNoSlash}
@@ -391,7 +391,7 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
         ${CI_TESTS} \
         ${ANALYZER_MTR_ARGS} \
         --junit-output=${RESULTS_DIR}/junit_ci_fs.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.ci_fs" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.ci_fs" || true
 
     ln -s /tmp/ci_disk_dir/var $PWD/var_ci_fs
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_ci_fs ${RESULTS_DIR}/mtr_var
@@ -442,7 +442,7 @@ if [[ "${WITH_PS_PROTOCOL}" = 'yes' ]]; then
         ${PS_TESTS} \
         ${ANALYZER_MTR_ARGS} \
         --junit-output=${RESULTS_DIR}/junit_ps_protocol.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.ps_protocol" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.ps_protocol" || true
 
     ln -s $PWD/var $PWD/var_ps_protocol
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_ps_protocol ${RESULTS_DIR}/mtr_var
@@ -486,7 +486,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
         --junit-output=${RESULTS_DIR}/junit_keyring_vault_dev_v1.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_dev_v1" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_dev_v1" || true
 
     ln -s $PWD/var $PWD/var_kv1_dev
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv1_dev ${RESULTS_DIR}/mtr_var
@@ -507,7 +507,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
         --junit-output=${RESULTS_DIR}/junit_keyring_vault_dev_v2.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_dev_v2" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_dev_v2" || true
 
     ln -s $PWD/var $PWD/var_kv2_dev
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv2_dev ${RESULTS_DIR}/mtr_var
@@ -530,7 +530,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
         --junit-output=${RESULTS_DIR}/junit_keyring_vault_prod_v1.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_prod_v1" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_prod_v1" || true
 
     ln -s $PWD/var $PWD/var_kv1_prod
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv1_prod ${RESULTS_DIR}/mtr_var
@@ -552,7 +552,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
         --junit-output=${RESULTS_DIR}/junit_keyring_vault_prod_v2.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.keyring_vault_prod_v2" || true
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_prod_v2" || true
 
     ln -s $PWD/var $PWD/var_kv2_prod
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv2_prod ${RESULTS_DIR}/mtr_var

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -19,6 +19,61 @@
 set -o errexit
 set -o xtrace
 
+function execute() {
+    local suites=$1
+    local parallel=$2
+    local extraOptions=$3
+    local logFileSuffix=$4
+
+    if [[ -z ${suites} ]]; then
+        return
+    fi
+
+    local worker="WORKER_${WORKER_NO}_${logFileSuffix}"
+    # ensure that there are not / in worker name (it can come from suites that have / in their names)
+    worker=${worker//"/"/"_"}
+
+    echo "Executing suites $suites, logFileSuffix: $logFileSuffix"
+
+    df -h
+    du /dev/shm
+    mount
+    ls -la /dev/shm
+    cat /proc/meminfo
+
+    start=`date +%s`
+
+    MTR_ARGS_NORMAL=${MTR_ARGS}
+
+    MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+        --parallel=${parallel} \
+        --result-file \
+        --suite=$suites \
+        --suite-timeout=9999 \
+        --testcase-timeout=${TESTCASE_TIMEOUT} \
+        --force ${MYSQLD_ENV} \
+        --max-test-fail=0 \
+        ${MTR_ARGS_NORMAL} \
+        ${extraOptions} \
+        --junit-output=${RESULTS_DIR}/junit_${worker}.xml \
+        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${worker}" || true
+
+    ln -s $PWD/var $PWD/var_${worker}
+    which rsync
+    rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${worker} ${RESULTS_DIR}/mtr_var
+
+    pgrep -f mysqld | xargs -r kill -9 2>/dev/null || true
+
+    rm -rf $PWD/var_${worker}
+
+    df -h
+    du -sh /dev/shm
+
+    end=`date +%s`
+    runtime=$((end-start))
+    echo KH,SUITES,${suites}-${logFileSuffix},time,$runtime
+}
+
 WORKDIR=$(cd ${1:-./build}; pwd -P)
 BUILD_DIR=${WORKDIR}/build
 RESULTS_DIR=${WORKDIR}/results
@@ -209,11 +264,11 @@ if [[ "${ANALYZER_OPTS}" == *WITH_ASAN=ON* ]]; then
 fi
 
 #
-# set options for "--mysqld-env"
+# adjustments for Valgrind
 if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
-    MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${EATMYDATA}"
+    MYSQLD_ENV=--mysqld-env=\"LD_PRELOAD=${ADD_TO_LD_PRELOAD:-}${EATMYDATA}\"
 else
-    MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
+    MYSQLD_ENV=--mysqld-env=\"LD_PRELOAD=${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}\"
 fi
 
 
@@ -258,82 +313,11 @@ echo "MTR big suites: $suitesBig"
 
 start=`date +%s`
 
-if [[ "$suitesNormal" != "" ]]; then
-    suitesNormal=${suitesNormal::-1};
-    suiteNoSlash="WORKER_${WORKER_NO}"
-    echo "Executing normal tests for suites $suitesNormal"
-
-    df -h
-    du /dev/shm
-    mount
-    ls -la /dev/shm
-    cat /proc/meminfo
-
-    MTR_ARGS_NORMAL=${MTR_ARGS}
-
-    MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-        --parallel=${PARALLEL} \
-        --result-file \
-        --suite=$suitesNormal \
-        --suite-timeout=9999 \
-        --testcase-timeout=${TESTCASE_TIMEOUT} \
-        ${MTR_ARGS_NORMAL} \
-        --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
-        --max-test-fail=0 \
-        --junit-output=${RESULTS_DIR}/junit_${suiteNoSlash}.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
-
-    ln -s $PWD/var $PWD/var_${suiteNoSlash}
-    which rsync
-    rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${suiteNoSlash} ${RESULTS_DIR}/mtr_var
-
-    killall -9 mysqld || true
-    rm -rf $PWD/var_${suiteNoSlash}
-
-    df -h
-    du -sh /dev/shm
-
-    end=`date +%s`
-    runtime=$((end-start))
-    echo KH,SUITE_NO_BIG,${suitesNormal},time,$runtime
-fi
-
-if [[ "$suitesBig" != "" ]]; then
-    suitesBig=${suitesBig::-1};
-    suiteNoSlash="WORKER_${WORKER_NO}"
-    echo "Executing big tests for suites $suitesBig"
-
-    MTR_ARGS_BIG=${MTR_ARGS}
-    MTR_ARGS_BIG+=" --only-big-test"
-    suiteNoSlash+="_bigtest"
-    TESTCASE_TIMEOUT_BIG=$((TESTCASE_TIMEOUT * 2))
-
-    MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-        --parallel=${PARALLEL} \
-        --result-file \
-        --suite=$suitesBig \
-        --suite-timeout=9999 \
-        --testcase-timeout=${TESTCASE_TIMEOUT} \
-        ${MTR_ARGS_BIG} \
-        --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
-        --max-test-fail=0 \
-        --junit-output=${RESULTS_DIR}/junit_${suiteNoSlash}.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${suiteNoSlash}" || true
-
-    ln -s $PWD/var $PWD/var_${suiteNoSlash}
-    rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_${suiteNoSlash} ${RESULTS_DIR}/mtr_var
-
-    killall -9 mysqld || true
-    rm -rf $PWD/var_${suiteNoSlash}
-
-    df -h
-    du -sh /dev/shm
-
-    end=`date +%s`
-    runtime=$((end-start))
-    echo KH,SUITE_TOTAL,${suitesBig},time,$runtime
-fi
+# execute $suites $parallel $extraOptions $logFileSuffix
+execute "$suitesNormal" "${PARALLEL}" "" ""
+execute "$suitesBig" "${PARALLEL}" "--only-big-test" "_bigtest"
 # <<<< main MTR execution loop ends here
+
 
 #
 # CI FS tests
@@ -370,7 +354,7 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
 
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --result-file \
-        --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
+        --force ${MYSQLD_ENV} \
         --max-test-fail=0 \
         --suite-timeout=9999 \
         --parallel=$PARALLEL \
@@ -422,7 +406,7 @@ if [[ "${WITH_PS_PROTOCOL}" = 'yes' ]]; then
 
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --result-file \
-        --force --mysqld-env="LD_PRELOAD=${MYSQLD_ENV}" \
+        --force ${MYSQLD_ENV} \
         --max-test-fail=0 \
         --suite-timeout=9999 \
         --parallel=$PARALLEL \

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -15,9 +15,13 @@
 #      KEYRING_VAULT_MTR = (yes no)
 #      WITH_ROCKSDB = (ON OFF)
 #      KEEP_BUILD = (yes no)
+#      EXECUTE_SUITES_ONE_BY_ONE = (yes no)
 
 set -o errexit
 set -o xtrace
+
+# Execution mode. If suites should be executed one by one, or all together
+echo EXECUTE_SUITES_ONE_BY_ONE=$EXECUTE_SUITES_ONE_BY_ONE
 
 function execute() {
     local suites=$1
@@ -29,7 +33,7 @@ function execute() {
         return
     fi
 
-    local worker="WORKER_${WORKER_NO}_${logFileSuffix}"
+    local worker="WORKER_${WORKER_NO}${logFileSuffix}"
     # ensure that there are not / in worker name (it can come from suites that have / in their names)
     worker=${worker//"/"/"_"}
 
@@ -74,7 +78,26 @@ function execute() {
     echo KH,SUITES,${suites}-${logFileSuffix},time,$runtime
 }
 
-split_suites() {
+function executeSuites() {
+  local suites="$1"
+  local parallel="$2"
+  local extraOptions="$3"
+  local extraSuffix=${4:+-"$4"}
+
+  if [[ "${EXECUTE_SUITES_ONE_BY_ONE}" != "yes" ]]; then
+    # Run all suites together
+    execute "$suites" "$parallel" "$extraOptions" "$extraSuffix"
+  else
+    # Run suites one by one
+    IFS=',' read -ra suiteList <<< "$suites"
+    for suite in "${suiteList[@]}"; do
+      echo "Executing suite: $suite"
+      execute "$suite" "$parallel" "$extraOptions" "_${suite}${extraSuffix}"
+    done
+  fi
+}
+
+function split_suites() {
   local input="$1"
   suitesNormal=""
   suitesBig=""
@@ -310,16 +333,14 @@ split_suites "$MTR_SUITES"
 echo "MTR normal suites: $suitesNormal"
 echo "MTR big suites: $suitesBig"
 
-start=`date +%s`
-
 if [[ "$ONLY_BIG_TEST" == "1" ]]; then
-  execute "$suitesBig"    "${PARALLEL}" "--only-big-test" "_bigtest"
+  executeSuites "$suitesBig"    "${PARALLEL}" "--only-big-test" "big"
 elif [[ "$BIG_TEST" == "1" ]]; then
-  execute "$suitesNormal" "${PARALLEL}" "" ""
-  execute "$suitesBig" "   ${PARALLEL}" "--only-big-test" "_bigtest"
+  executeSuites "$suitesNormal" "${PARALLEL}" "" ""
+  executeSuites "$suitesBig"    "${PARALLEL}" "--only-big-test" "big"
 else
-  # execute $suites $parallel $extraOptions $logFileSuffix
-  execute "$suitesNormal" "${PARALLEL}" "" ""
+  # executeSuites $suites $parallel $extraOptions $logFileSuffix
+  executeSuites "$suitesNormal" "${PARALLEL}" "" ""
 fi
 # <<<< main MTR execution loop ends here
 

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -74,6 +74,33 @@ function execute() {
     echo KH,SUITES,${suites}-${logFileSuffix},time,$runtime
 }
 
+split_suites() {
+  local input="$1"
+  suitesNormal=""
+  suitesBig=""
+
+  # Split input by comma
+  IFS=',' read -ra suites <<< "$input"
+
+  for suite in "${suites[@]}"; do
+    case "$suite" in
+      *"|nobig")
+        suite_name="${suite%%|*}"
+        suitesNormal+="${suitesNormal:+,}$suite_name"
+        ;;
+      *"|big")
+        suite_name="${suite%%|*}"
+        suitesBig+="${suitesBig:+,}$suite_name"
+        ;;
+      *)
+        # No suffix → add to both
+        suitesNormal+="${suitesNormal:+,}$suite"
+        suitesBig+="${suitesBig:+,}$suite"
+        ;;
+    esac
+  done
+}
+
 WORKDIR=$(cd ${1:-./build}; pwd -P)
 BUILD_DIR=${WORKDIR}/build
 RESULTS_DIR=${WORKDIR}/results
@@ -276,46 +303,24 @@ fi
 # Running MTR test cases
 MTR_ARGS="${MTR_ARGS} --no-unit-tests"
 
-ARRAY_MTR_SUITES=($(echo $MTR_SUITES | sed 's/,/ /g'))
+
 # >>>> main MTR execution loop starts here
-for suite in "${ARRAY_MTR_SUITES[@]}"; do
-    only_big_tests_this=$ONLY_BIG_TEST
-    big_tests_this=$BIG_TEST
-
-    # suite may be in form:
-    # main
-    # main|big
-    # main|nobig
-    arrSuite=(${suite//|/ })
-    suite=${arrSuite[0]}
-    big=${arrSuite[1]}
-
-    if [[ "${big}" == "big" ]]; then
-        only_big_tests_this=1
-        # if big tests are executed or not depends on --big-tests
-    fi
-    if [[ "${big}" == "nobig" ]]; then
-        # if normal tests are executed or not depends on --big-tests
-        big_tests_this=0
-    fi
-
-    if [[ $only_big_tests_this == "0" ]]; then
-        suitesNormal+="$suite,"
-    fi
-
-    if [[ $big_tests_this == "1" ]]; then
-        suitesBig+="$suite,"
-    fi
-done
+split_suites "$MTR_SUITES"
 
 echo "MTR normal suites: $suitesNormal"
 echo "MTR big suites: $suitesBig"
 
 start=`date +%s`
 
-# execute $suites $parallel $extraOptions $logFileSuffix
-execute "$suitesNormal" "${PARALLEL}" "" ""
-execute "$suitesBig" "${PARALLEL}" "--only-big-test" "_bigtest"
+if [[ "$ONLY_BIG_TEST" == "1" ]]; then
+  execute "$suitesBig"    "${PARALLEL}" "--only-big-test" "_bigtest"
+elif [[ "$BIG_TEST" == "1" ]]; then
+  execute "$suitesNormal" "${PARALLEL}" "" ""
+  execute "$suitesBig" "   ${PARALLEL}" "--only-big-test" "_bigtest"
+else
+  # execute $suites $parallel $extraOptions $logFileSuffix
+  execute "$suitesNormal" "${PARALLEL}" "" ""
+fi
 # <<<< main MTR execution loop ends here
 
 


### PR DESCRIPTION
1. Port `execute` function from PXC pipelines
2. Introduce `split_suites` function -> divide into `normal` and `big` tests
3. Introduce `EXECUTE_SUITES_ONE_BY_ONE` parameter
4. Unify format of file names for Jenkins XML results
