### PR TITLE
PS-10188: Create parallel pipeline for PS/MYSQL 5.7

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -112,6 +112,7 @@ docker run --rm --shm-size=32G \
     export VAULT_V1_PROD_MTR_TOKEN='${VAULT_V1_PROD_MTR_TOKEN}'
     export VAULT_V2_PROD_MTR_TOKEN='${VAULT_V2_PROD_MTR_TOKEN}'
     export DOCKER_OS='${SOURCE_IMAGE}'
+    export GIT_REPO='${GIT_REPO}'
     export WITH_ROCKSDB='${WITH_ROCKSDB}'
     export KEEP_BUILD='${KEEP_BUILD}'
     export EXECUTE_SUITES_ONE_BY_ONE='${EXECUTE_SUITES_ONE_BY_ONE}'

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -237,9 +237,9 @@
       - project: percona-server-{ps_version}-pipeline-parallel-mtr
         current-parameters: true
         predefined-parameters: |
-          DOCKER_OS=${{DOCKER_OS}}
-          ARCH=${{ARCH}}
-          CMAKE_BUILD_TYPE=${{CMAKE_BUILD_TYPE}}
+          DOCKER_OS=${DOCKER_OS}
+          ARCH=${ARCH}
+          CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           LAUNCHER_USER_ID=$BUILD_USER_ID
         block: true
         block-thresholds:
@@ -260,29 +260,6 @@
         echo "${{TRIGGERED_BUILD_NUMBERS_percona_server_{ps_version_no_dot}_pipeline_parallel_mtr}}" > PIPELINE_BUILD_NUMBER
         gunzip build.log.gz
     publishers:
-    - raw:
-        xml: !!binary |
-          PGlvLmplbmtpbnMucGx1Z2lucy5hbmFseXNpcy5jb3JlLnN0ZXBzLklzc3Vlc1JlY29yZGVyIHBs
-          dWdpbj0id2FybmluZ3MtbmdAOS4wLjEiPgogICAgICA8YW5hbHlzaXNUb29scz4KICAgICAgICA8
-          aW8uamVua2lucy5wbHVnaW5zLmFuYWx5c2lzLndhcm5pbmdzLkdjYzQ+CiAgICAgICAgICA8aWQg
-          Lz4KICAgICAgICAgIDxuYW1lIC8+CiAgICAgICAgICA8cGF0dGVybj5idWlsZC5sb2c8L3BhdHRl
-          cm4+CiAgICAgICAgICA8cmVwb3J0RW5jb2RpbmcgLz4KICAgICAgICAgIDxza2lwU3ltYm9saWNM
-          aW5rcz5mYWxzZTwvc2tpcFN5bWJvbGljTGlua3M+CiAgICAgICAgPC9pby5qZW5raW5zLnBsdWdp
-          bnMuYW5hbHlzaXMud2FybmluZ3MuR2NjND4KICAgICAgPC9hbmFseXNpc1Rvb2xzPgogICAgICA8
-          c291cmNlQ29kZUVuY29kaW5nIC8+CiAgICAgIDxzb3VyY2VEaXJlY3RvcnkgLz4KICAgICAgPGln
-          bm9yZVF1YWxpdHlHYXRlPmZhbHNlPC9pZ25vcmVRdWFsaXR5R2F0ZT4KICAgICAgPGlnbm9yZUZh
-          aWxlZEJ1aWxkcz50cnVlPC9pZ25vcmVGYWlsZWRCdWlsZHM+CiAgICAgIDxmYWlsT25FcnJvcj5m
-          YWxzZTwvZmFpbE9uRXJyb3I+CiAgICAgIDxoZWFsdGh5PjA8L2hlYWx0aHk+CiAgICAgIDx1bmhl
-          YWx0aHk+MDwvdW5oZWFsdGh5PgogICAgICA8bWluaW11bVNldmVyaXR5IHBsdWdpbj0iYW5hbHlz
-          aXMtbW9kZWwtYXBpQDEwLjAuMCI+CiAgICAgICAgPG5hbWU+TE9XPC9uYW1lPgogICAgICA8L21p
-          bmltdW1TZXZlcml0eT4KICAgICAgPGZpbHRlcnMgLz4KICAgICAgPGlzRW5hYmxlZEZvckZhaWx1
-          cmU+dHJ1ZTwvaXNFbmFibGVkRm9yRmFpbHVyZT4KICAgICAgPGlzQWdncmVnYXRpbmdSZXN1bHRz
-          PmZhbHNlPC9pc0FnZ3JlZ2F0aW5nUmVzdWx0cz4KICAgICAgPGlzQmxhbWVEaXNhYmxlZD5mYWxz
-          ZTwvaXNCbGFtZURpc2FibGVkPgogICAgICA8c2tpcFB1Ymxpc2hpbmdDaGVja3M+ZmFsc2U8L3Nr
-          aXBQdWJsaXNoaW5nQ2hlY2tzPgogICAgICA8cHVibGlzaEFsbElzc3Vlcz5mYWxzZTwvcHVibGlz
-          aEFsbElzc3Vlcz4KICAgICAgPHF1YWxpdHlHYXRlcyAvPgogICAgICA8dHJlbmRDaGFydFR5cGU+
-          QUdHUkVHQVRJT05fVE9PTFM8L3RyZW5kQ2hhcnRUeXBlPgogICAgICA8c2NtIC8+CiAgICA8L2lv
-          LmplbmtpbnMucGx1Z2lucy5hbmFseXNpcy5jb3JlLnN0ZXBzLklzc3Vlc1JlY29yZGVyPgogIA==
     - junit:
         results: "**/*.xml"
         keep-long-stdio: true

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -514,13 +514,10 @@ void triggerAbortedTestWorkersRerun() {
     }
 }
 
-def validatePsBranch() {
-    echo 'Validating PS branch version'
+def getServerVersion() {
+    echo 'Trying to get the server version'
     def serverVersion = sh(
       script: """#!/bin/bash
-        MY_BRANCH_BASE_MAJOR=8
-        MY_BRANCH_BASE_MINOR=0
-
         if [ -f /usr/bin/apt ]; then
             sudo apt-get update
         fi
@@ -537,19 +534,9 @@ def validatePsBranch() {
         fi
 
         RAW_VERSION_LINK=\$(echo \${GIT_REPO%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
-        REPLY=\$(curl -Is \${RAW_VERSION_LINK}/\${BRANCH}/MYSQL_VERSION | head -n 1 | awk '{print \$2}')
-        if [[ \${REPLY} != 200 ]]; then
-            wget \${RAW_VERSION_LINK}/\${BRANCH}/VERSION -O ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-        else
-            wget \${RAW_VERSION_LINK}/\${BRANCH}/MYSQL_VERSION -O ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-        fi
+        wget \${RAW_VERSION_LINK}/\${BRANCH}/MYSQL_VERSION -O ${WORKSPACE}/VERSION-${BUILD_NUMBER}
         source ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-        if [[ \${MYSQL_VERSION_MAJOR} -lt \${MY_BRANCH_BASE_MAJOR} ]] ; then
-            echo "Are you trying to build wrong branch?"
-            echo "You are trying to build \${MYSQL_VERSION_MAJOR}.\${MYSQL_VERSION_MINOR} instead of \${MY_BRANCH_BASE_MAJOR}.\${MY_BRANCH_BASE_MINOR}!"
-            rm -f ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-            exit 1
-        fi
+
         rm -f ${WORKSPACE}/VERSION-${BUILD_NUMBER}
         echo "\${MYSQL_VERSION_MAJOR}.\${MYSQL_VERSION_MINOR}.\${MYSQL_VERSION_PATCH}"
       """,
@@ -669,7 +656,7 @@ pipeline {
                 sh 'echo Prepare: \$(date -u "+%s")'
 
                 script {
-                    SERVER_VERSION = validatePsBranch()
+                    SERVER_VERSION = getServerVersion()
                     echo "Extracted SERVER_VERSION: ${SERVER_VERSION}"
                     setupTestSuitesSplit()
 

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -135,11 +135,11 @@ void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
 
 void cleanWorkspace(Integer WORKER_ID) {
     echo "[INFO] Worker ${WORKER_ID}: cleaning up workspace."
-    sh """
+    sh '''
         # "git clean" doesn't remove "sources/" because of ".gitignore"
         sudo git clean -xdf || :
         sudo rm -rf sources
-    """
+    '''
 }
 
 void doTests(String WORKER_ID, String SUITES, String STANDALONE_TESTS = '', boolean UNIT_TESTS = false, boolean CIFS_TESTS = false, boolean KV_TESTS = false, boolean PS_PROTOCOL_TESTS = false) {
@@ -233,12 +233,7 @@ void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDA
 
             // This is questionable. Do we need result XMLs in S3 cache while Jenkins archives them as well?
             syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')
-            step([
-                $class: 'JUnitResultArchiver',
-                testResults: "${WORK_DIR}/results/*.xml",
-                healthScaleFactor: 1.0,
-                keepLongStdio: false
-            ])
+            step([$class: 'JUnitResultArchiver', testResults: "${WORK_DIR}/results/*.xml", healthScaleFactor: 1.0, keepLongStdio: false])
 
             // cleanup before marking success
             cleanWorkspace(WORKER_ID)
@@ -277,14 +272,16 @@ void doTestWorkerJob(Integer WORKER_ID, String SUITES, String STANDALONE_TESTS =
 
 void checkoutSources() {
     echo 'Checkout PS sources'
-    sh '''
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git reset --hard
-        sudo git clean -xdf || :
-        sudo rm -rf sources
-        ./local/checkout
-    '''
+    withCredentials([string(credentialsId: 'JNKPercona', variable: 'JNKPercona_token')]) {
+        sh '''
+            # sudo is needed for better node recovery after compilation failure
+            # if building failed on compilation stage directory will have files owned by docker user
+            sudo git reset --hard
+            sudo git clean -xdf || :
+            sudo rm -rf sources
+            ./local/checkout
+        '''
+    }
 }
 
 void build(String SCRIPT) {
@@ -311,24 +308,94 @@ void build(String SCRIPT) {
     }  // timeout
 }
 
+def getServerVersionFromFile(String filePath) {
+    // Call Bash to source the file and echo the version
+    def serverVersion = sh(
+        script: """#!/bin/bash
+            if [ ! -f "${filePath}" ]; then
+                echo "${filePath} not found!" >&2
+                exit 1
+            fi
+
+            source "${filePath}"
+            rm -f "${filePath}"
+
+            echo "\${MYSQL_VERSION_MAJOR}.\${MYSQL_VERSION_MINOR}.\${MYSQL_VERSION_PATCH}\${MYSQL_VERSION_EXTRA}"
+        """,
+        returnStdout: true
+    ).trim()
+
+    return serverVersion
+}
+
+def getServerVersion() {
+    echo 'Trying to get the server version'
+
+    withCredentials([string(credentialsId: 'JNKPercona', variable: 'JNKPercona_token')]) {
+        sh '''#!/bin/bash
+            set -xe
+
+            if [ -f /usr/bin/apt ]; then
+                sudo apt-get update
+            fi
+
+            if [[ $USE_PR == "true" ]]; then
+                if [ -f /usr/bin/yum ]; then
+                    sudo yum -y install jq
+                else
+                    sudo apt-get install -y jq
+                fi
+
+                GIT_REPO=$(curl -s https://api.github.com/repos/percona/percona-server/pulls/$BRANCH | jq -r '.head.repo.html_url')
+                BRANCH=$(curl -s https://api.github.com/repos/percona/percona-server/pulls/$BRANCH | jq -r '.head.ref')
+            fi
+
+            GIT_REPO_LINK=${GIT_REPO}
+            if [[ "${GIT_REPO}" =~ post-eol|private ]]; then
+                GIT_REPO_LINK=$(echo ${GIT_REPO} | sed -e "s|github|x-access-token:${JNKPercona_token}@github|g")
+            fi
+            RAW_VERSION_LINK=$(echo ${GIT_REPO_LINK%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
+            REPLY=$(curl -Is ${RAW_VERSION_LINK}/${BRANCH}/MYSQL_VERSION | head -n 1 | awk '{print $2}')
+            if [[ ${REPLY} != 200 ]]; then
+                curl ${RAW_VERSION_LINK}/${BRANCH}/VERSION -o ${WORKSPACE}/VERSION-${BUILD_NUMBER}
+            else
+                curl ${RAW_VERSION_LINK}/${BRANCH}/MYSQL_VERSION -o ${WORKSPACE}/VERSION-${BUILD_NUMBER}
+            fi
+         '''
+    } // withCredentials
+
+    return getServerVersionFromFile("${WORKSPACE}/VERSION-${BUILD_NUMBER}")
+}
+
 void setupTestSuitesSplit() {
-    def split_script = """#!/bin/bash
+    withCredentials([string(credentialsId: 'JNKPercona', variable: 'JNKPercona_token')]) {
+    withEnv(["SERVER_VERSION=${SERVER_VERSION}"]) {
+    sh '''#!/bin/bash
+        set -xe
+
         if [[ "${FULL_MTR}" == "yes" ]]; then
             # Try to get suites split from PS repo. If not present, fallback to hardcoded.
-            RAW_VERSION_LINK=\$(echo \${GIT_REPO%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
-            REPLY=\$(curl -Is \${RAW_VERSION_LINK}/${BRANCH}/mysql-test/suites-groups.sh | head -n 1 | awk '{print \$2}')
+            GIT_REPO_LINK=${GIT_REPO}
+            if [[ "${GIT_REPO}" =~ post-eol|private ]]; then
+                GIT_REPO_LINK=$(echo ${GIT_REPO} | sed -e "s|github|x-access-token:${JNKPercona_token}@github|g")
+            fi
+            RAW_VERSION_LINK=$(echo ${GIT_REPO_LINK%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
+
+            REPLY=$(curl -Is ${RAW_VERSION_LINK}/${BRANCH}/mysql-test/suites-groups.sh | head -n 1 | awk '{print $2}')
             CUSTOM_SPLIT=0
-            if [[ \${REPLY} != 200 ]]; then
+            if [[ ${REPLY} != 200 ]]; then
                 # The given branch does not contain customized suites-groups.sh file. Use default configuration.
                 echo "Using pipeline built-in MTR suites split"
                 cp ./jenkins/suites-groups.sh ${WORKSPACE}/suites-groups.sh
             else
                 echo "Using custom MTR suites split"
-                wget \${RAW_VERSION_LINK}/${BRANCH}/mysql-test/suites-groups.sh -O ${WORKSPACE}/suites-groups.sh
+                curl ${RAW_VERSION_LINK}/${BRANCH}/mysql-test/suites-groups.sh -o ${WORKSPACE}/suites-groups.sh
                 CUSTOM_SPLIT=1
             fi
+            curl ${RAW_VERSION_LINK}/${BRANCH}/mysql-test/mysql-test-run.pl -o ${WORKSPACE}/mysql-test-run.pl
+            grep opt_only_big_test ${WORKSPACE}/mysql-test-run.pl || { echo "ERROR: Parallel MTRs require server that supports --only-big-test"; exit 1; }
+
             # Check if split contain all suites
-            wget \${RAW_VERSION_LINK}/${BRANCH}/mysql-test/mysql-test-run.pl -O ${WORKSPACE}/mysql-test-run.pl
             chmod +x ${WORKSPACE}/suites-groups.sh
             set +e
             echo "Check if suites list is consistent with the one specified in mysql-test-run.pl"
@@ -338,28 +405,29 @@ void setupTestSuitesSplit() {
             else
                 set_suites ${CMAKE_BUILD_TYPE} ${SERVER_VERSION}
             fi
-            check_suites ${WORKSPACE}/mysql-test-run.pl
-            CHECK_RESULT=\$?
-            set -e
-            echo "CHECK_RESULT: \${CHECK_RESULT}"
+            set +x
+            check_suites ${WORKSPACE}/mysql-test-run.pl ${SERVER_VERSION}
+            CHECK_RESULT=$?
+            set -xe
+            echo "CHECK_RESULT: ${CHECK_RESULT}"
             # Fail only if this is built-in split.
-            if [[ \${CUSTOM_SPLIT} -eq 0 ]] && [[ \${CHECK_RESULT} -ne 0 ]]; then
+            if [[ ${CUSTOM_SPLIT} -eq 0 ]] && [[ ${CHECK_RESULT} -ne 0 ]]; then
                 echo "Default MTR split is inconsistent. Exiting."
                 exit 1
             fi
 
-            echo \${WORKER_1_MTR_SUITES} > ${WORKSPACE}/worker_1.suites
-            echo \${WORKER_2_MTR_SUITES} > ${WORKSPACE}/worker_2.suites
-            echo \${WORKER_3_MTR_SUITES} > ${WORKSPACE}/worker_3.suites
-            echo \${WORKER_4_MTR_SUITES} > ${WORKSPACE}/worker_4.suites
-            echo \${WORKER_5_MTR_SUITES} > ${WORKSPACE}/worker_5.suites
-            echo \${WORKER_6_MTR_SUITES} > ${WORKSPACE}/worker_6.suites
-            echo \${WORKER_7_MTR_SUITES} > ${WORKSPACE}/worker_7.suites
-            echo \${WORKER_8_MTR_SUITES} > ${WORKSPACE}/worker_8.suites
+            echo ${WORKER_1_MTR_SUITES} > ${WORKSPACE}/worker_1.suites
+            echo ${WORKER_2_MTR_SUITES} > ${WORKSPACE}/worker_2.suites
+            echo ${WORKER_3_MTR_SUITES} > ${WORKSPACE}/worker_3.suites
+            echo ${WORKER_4_MTR_SUITES} > ${WORKSPACE}/worker_4.suites
+            echo ${WORKER_5_MTR_SUITES} > ${WORKSPACE}/worker_5.suites
+            echo ${WORKER_6_MTR_SUITES} > ${WORKSPACE}/worker_6.suites
+            echo ${WORKER_7_MTR_SUITES} > ${WORKSPACE}/worker_7.suites
+            echo ${WORKER_8_MTR_SUITES} > ${WORKSPACE}/worker_8.suites
         fi
-    """
-    def split_script_output = sh(script: split_script, returnStdout: true)
-    echo split_script_output
+    '''
+    } // withEnv
+    } // withCredentials
 
     script {
         if (env.FULL_MTR == 'yes') {
@@ -512,38 +580,6 @@ void triggerAbortedTestWorkersRerun() {
             }
         }  // env.ALLOW_ABORTED_WORKERS_RERUN
     }
-}
-
-def getServerVersion() {
-    echo 'Trying to get the server version'
-    def serverVersion = sh(
-      script: """#!/bin/bash
-        if [ -f /usr/bin/apt ]; then
-            sudo apt-get update
-        fi
-
-        if [[ ${USE_PR} == "true" ]]; then
-            if [ -f /usr/bin/yum ]; then
-                sudo yum -y install jq
-            else
-                sudo apt-get install -y jq
-            fi
-
-            GIT_REPO=\$(curl -s https://api.github.com/repos/percona/percona-server/pulls/${BRANCH} | jq -r '.head.repo.html_url')
-            BRANCH=\$(curl -s https://api.github.com/repos/percona/percona-server/pulls/${BRANCH} | jq -r '.head.ref')
-        fi
-
-        RAW_VERSION_LINK=\$(echo \${GIT_REPO%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
-        wget \${RAW_VERSION_LINK}/\${BRANCH}/MYSQL_VERSION -O ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-        source ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-
-        rm -f ${WORKSPACE}/VERSION-${BUILD_NUMBER}
-        echo "\${MYSQL_VERSION_MAJOR}.\${MYSQL_VERSION_MINOR}.\${MYSQL_VERSION_PATCH}"
-      """,
-      returnStdout: true
-    ).trim()
-
-    return serverVersion.readLines().last()
 }
 
 // functions end here

--- a/local/build-binary
+++ b/local/build-binary
@@ -88,7 +88,7 @@ wget_loop() {
 }
 
 # Boost is not required for MySQL/PS 8.4.x or 9.y.z
-if [[ "${MYSQL_VERSION}" == 8.0.* ]]; then
+if [[ "${MYSQL_VERSION}" == 8.0.* || "${MYSQL_VERSION}" == 5.7.* ]]; then
     BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
     wget_loop "boost_${BOOST_VERSION}.tar.bz2" "https://archives.boost.io/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.bz2"
 fi
@@ -155,7 +155,7 @@ else
     WITH_MECAB="system"
 fi
 
-if [[ "${MYSQL_VERSION}" == 8.0.* ]]; then
+if [[ "${MYSQL_VERSION}" == 8.0.* || "${MYSQL_VERSION}" == 5.7.* ]]; then
     CMAKE_OPTS+=" -DWITH_KEYRING_VAULT=ON -DWITH_KEYRING_VAULT_TEST=ON"
 fi
 
@@ -184,6 +184,10 @@ if [[ ${WITH_JS_LANG} == 'ON' ]]; then
         tar -xzf ${V8_ARCHIVE_NAME}.tar.gz
         rm -rf ${V8_ARCHIVE_NAME}.tar.gz
     popd
+fi
+
+if [[ "${MYSQL_VERSION}" == 5.7.* ]]; then
+    EXTRA_OPTS="-DWITH_TOKUDB=OFF -DWITH_EMBEDDED_SERVER=ON -DWITH_SCALABILITY_METRICS=ON -DENABLE_DOWNLOADS=ON"
 fi
 
 # ------------------------------------------------------------------------------
@@ -224,6 +228,7 @@ pushd ${BUILD_DIR}
         ${TARGET_CFLAGS:+-DCMAKE_C_FLAGS="${TARGET_CFLAGS}" -DCMAKE_CXX_FLAGS="${TARGET_CFLAGS}"} \
         ${ANALYZER_OPTS} \
         ${CMAKE_OPTS} \
+        ${EXTRA_OPTS} \
         ${SOURCEDIR} | tee ${WORKDIR}/cmake.log
     make ${MAKE_OPTS} | tee ${WORKDIR}/make_build.log
     make -j$(nproc) DESTDIR=${INSTALL_DIR} install | tee ${WORKDIR}/make_install.log

--- a/local/checkout
+++ b/local/checkout
@@ -10,6 +10,9 @@ set -o xtrace
 ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)/sources
 
 if [ ! -d "${ROOT_DIR}" ]; then
+    if [[ "${GIT_REPO}" =~ post-eol|private ]]; then
+        GIT_REPO=$(echo ${GIT_REPO} | sed -e "s|github|${JNKPercona_token}@github|")
+    fi
     git clone "${GIT_REPO:-https://github.com/percona/percona-server}" "${ROOT_DIR}"
 fi
 

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -24,20 +24,15 @@ set -o xtrace
 echo EXECUTE_SUITES_ONE_BY_ONE=$EXECUTE_SUITES_ONE_BY_ONE
 
 function execute() {
-    local suites=$1
-    local parallel=$2
-    local extraOptions=$3
-    local logFileSuffix=$4
-
-    if [[ -z ${suites} ]]; then
-        return
-    fi
-
+    local parallel=$1
+    local extraOptions=$2
+    local logFileSuffix=$3
     local worker="WORKER_${WORKER_NO}${logFileSuffix}"
+
     # ensure that there are not / in worker name (it can come from suites that have / in their names)
     worker=${worker//"/"/"_"}
 
-    echo "Executing suites $suites, logFileSuffix: $logFileSuffix"
+    echo "Executing $extraOptions, logFileSuffix: $logFileSuffix"
 
     df -h
     du /dev/shm
@@ -52,7 +47,6 @@ function execute() {
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --parallel=${parallel} \
         --result-file \
-        --suite=$suites \
         --suite-timeout=9999 \
         --testcase-timeout=${TESTCASE_TIMEOUT} \
         --force ${MYSQLD_ENV} \
@@ -84,15 +78,19 @@ function executeSuites() {
   local extraOptions="$3"
   local extraSuffix=${4:+-"$4"}
 
+  if [[ -z ${suites} ]]; then
+    return
+  fi
+
   if [[ "${EXECUTE_SUITES_ONE_BY_ONE}" != "yes" ]]; then
     # Run all suites together
-    execute "$suites" "$parallel" "$extraOptions" "$extraSuffix"
+    execute "$parallel" "--suite=$suites $extraOptions" "$extraSuffix"
   else
     # Run suites one by one
     IFS=',' read -ra suiteList <<< "$suites"
     for suite in "${suiteList[@]}"; do
       echo "Executing suite: $suite"
-      execute "$suite" "$parallel" "$extraOptions" ".${suite}${extraSuffix}"
+      execute "$parallel" "--suite=$suite $extraOptions" ".${suite}${extraSuffix}"
     done
   fi
 }

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -42,6 +42,12 @@ function execute() {
 
     start=`date +%s`
 
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_ARGS=" --junit-output=${RESULTS_DIR}/junit_${worker}.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${worker}"
+    else
+        JUNIT_ARGS=" --xml-report=${RESULTS_DIR}/junit_${worker}.xml"
+    fi
+
     MTR_ARGS_NORMAL=${MTR_ARGS}
 
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
@@ -53,8 +59,7 @@ function execute() {
         --max-test-fail=0 \
         ${MTR_ARGS_NORMAL} \
         ${extraOptions} \
-        --junit-output=${RESULTS_DIR}/junit_${worker}.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.${worker}" || true
+        ${JUNIT_ARGS} || true
 
     ln -s $PWD/var $PWD/var_${worker}
     which rsync
@@ -242,6 +247,7 @@ cd ${EXTRACT_DIR}/mysql-test
 #
 # >>>> execute all unit tests at the beginning with main.1st only using an original build (not files for ".tar.gz" archive)
 if [[ $UNIT_TESTS == "1" ]]; then
+    # /tmp/sources is required by an original build in $BUILD_DIR to run unit tests
     tests="main.1st"
     suiteNoSlash="UNIT_TESTS"
     echo "Executing unit tests with $tests"
@@ -262,6 +268,14 @@ if [[ $UNIT_TESTS == "1" ]]; then
         )
     fi
 
+    ls -l /tmp/sources/mysql-test || :
+    grep -q "opt_junit_package" /tmp/sources/mysql-test/mysql-test-run.pl && HAVE_JUNIT=1 || HAVE_JUNIT=0
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_UNIT_TESTS_ARGS=" --junit-output=${RESULTS_DIR}/junit_${suiteNoSlash}.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.${suiteNoSlash}"
+    else
+        JUNIT_UNIT_TESTS_ARGS=" --xml-report=${RESULTS_DIR}/junit_${suiteNoSlash}.xml"
+    fi
+
     pushd ${BUILD_DIR}/mysql-test
     env "${MTR_VAULT_ARRAY[@]}" MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --parallel=${PARALLEL} \
@@ -271,8 +285,7 @@ if [[ $UNIT_TESTS == "1" ]]; then
         ${MTR_ARGS} \
         --force \
         --max-test-fail=0 \
-        --junit-output=${RESULTS_DIR}/junit_${suiteNoSlash}.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.${suiteNoSlash}" || true
+        ${JUNIT_UNIT_TESTS_ARGS} || true
     popd
 
     ln -s ${BUILD_DIR}/mysql-test/var $PWD/var_${suiteNoSlash}
@@ -326,6 +339,9 @@ MTR_ARGS="${MTR_ARGS} --no-unit-tests"
 
 
 # >>>> main MTR execution loop starts here
+# Check if --junit-package option is avail from mysql-test-run.pl
+grep -q "opt_junit_package" ${EXTRACT_DIR}/mysql-test/mysql-test-run.pl && HAVE_JUNIT=1 || HAVE_JUNIT=0
+
 split_suites "$MTR_SUITES"
 
 echo "MTR normal suites: $suitesNormal"
@@ -376,6 +392,12 @@ if [[ "${CI_FS_MTR}" == 'yes' ]]; then
     done
     set -x
 
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_CI_FS_ARGS=" --junit-output=${RESULTS_DIR}/junit_ci_fs.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.ci_fs"
+    else
+        JUNIT_CI_FS_ARGS=" --xml-report=${RESULTS_DIR}/junit_ci_fs.xml"
+    fi
+
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --result-file \
         --force ${MYSQLD_ENV} \
@@ -388,8 +410,7 @@ if [[ "${CI_FS_MTR}" == 'yes' ]]; then
         --vardir="/tmp/ci_disk_dir/var" \
         ${CI_TESTS} \
         ${ANALYZER_MTR_ARGS} \
-        --junit-output=${RESULTS_DIR}/junit_ci_fs.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.ci_fs" || true
+        ${JUNIT_CI_FS_ARGS} || true
 
     ln -s /tmp/ci_disk_dir/var $PWD/var_ci_fs
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_ci_fs ${RESULTS_DIR}/mtr_var
@@ -428,6 +449,12 @@ if [[ "${SERVER_VERSION}" != 5.7.* && "${WITH_PS_PROTOCOL}" == 'yes' ]]; then
     done
     set -x
 
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_PS_PROTOCOL_ARGS=" --junit-output=${RESULTS_DIR}/junit_ps_protocol.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.ps_protocol"
+    else
+        JUNIT_PS_PROTOCOL_ARGS=" --xml-report=${RESULTS_DIR}/junit_ps_protocol.xml"
+    fi
+
     MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
         --result-file \
         --force ${MYSQLD_ENV} \
@@ -439,8 +466,7 @@ if [[ "${SERVER_VERSION}" != 5.7.* && "${WITH_PS_PROTOCOL}" == 'yes' ]]; then
         ${MTR_ARGS_PS} \
         ${PS_TESTS} \
         ${ANALYZER_MTR_ARGS} \
-        --junit-output=${RESULTS_DIR}/junit_ps_protocol.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.ps_protocol" || true
+        ${JUNIT_PS_PROTOCOL_ARGS} || true
 
     ln -s $PWD/var $PWD/var_ps_protocol
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_ps_protocol ${RESULTS_DIR}/mtr_var
@@ -471,6 +497,12 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
     fi
 
     echo "Running tests with Hashicorp Vault in Dev mode"
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_VAULT_V1_DEV_TC_ARGS=" --junit-output=${RESULTS_DIR}/junit_keyring_vault_dev_v1.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_dev_v1"
+    else
+        JUNIT_VAULT_V1_DEV_TC_ARGS=" --xml-report=${RESULTS_DIR}/junit_keyring_vault_dev_v1.xml"
+    fi
+
     MTR_VAULT_ADDRESS=${VAULT_V1_DEV_ADDRESS} \
     MTR_VAULT_ADMIN_TOKEN=${VAULT_V1_DEV_ROOT_TOKEN} \
     MTR_VAULT_PLUGIN_TOKEN=${VAULT_V1_DEV_MTR_TOKEN} \
@@ -483,14 +515,19 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV} \
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
-        --junit-output=${RESULTS_DIR}/junit_keyring_vault_dev_v1.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_dev_v1" || true
+        ${JUNIT_VAULT_V1_DEV_TC_ARGS} || true
 
     ln -s $PWD/var $PWD/var_kv1_dev
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv1_dev ${RESULTS_DIR}/mtr_var
 
     killall -9 mysqld || true
     rm -rf $PWD/var_kv1_dev
+
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_VAULT_V2_DEV_TC_ARGS=" --junit-output=${RESULTS_DIR}/junit_keyring_vault_dev_v2.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_dev_v2"
+    else
+        JUNIT_VAULT_V2_DEV_TC_ARGS=" --xml-report=${RESULTS_DIR}/junit_keyring_vault_dev_v2.xml"
+    fi
 
     MTR_VAULT_ADDRESS=${VAULT_V2_DEV_ADDRESS} \
     MTR_VAULT_ADMIN_TOKEN=${VAULT_V2_DEV_ROOT_TOKEN} \
@@ -504,8 +541,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV} \
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
-        --junit-output=${RESULTS_DIR}/junit_keyring_vault_dev_v2.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_dev_v2" || true
+        ${JUNIT_VAULT_V2_DEV_TC_ARGS} || true
 
     ln -s $PWD/var $PWD/var_kv2_dev
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv2_dev ${RESULTS_DIR}/mtr_var
@@ -514,6 +550,12 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
     rm -rf $PWD/var_kv2_dev
 
     echo "Running tests with Hashicorp Vault in Production mode"
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_VAULT_V1_PROD_TC_ARGS=" --junit-output=${RESULTS_DIR}/junit_keyring_vault_prod_v1.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_prod_v1"
+    else
+        JUNIT_VAULT_V1_PROD_TC_ARGS=" --xml-report=${RESULTS_DIR}/junit_keyring_vault_prod_v1.xml"
+    fi
+
     MTR_VAULT_ADDRESS=${VAULT_V1_PROD_ADDRESS} \
     MTR_VAULT_ADMIN_TOKEN=${VAULT_V1_PROD_ROOT_TOKEN} \
     MTR_VAULT_PLUGIN_TOKEN=${VAULT_V1_PROD_MTR_TOKEN} \
@@ -527,14 +569,19 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV} \
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
-        --junit-output=${RESULTS_DIR}/junit_keyring_vault_prod_v1.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_prod_v1" || true
+        ${JUNIT_VAULT_V1_PROD_TC_ARGS} || true
 
     ln -s $PWD/var $PWD/var_kv1_prod
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv1_prod ${RESULTS_DIR}/mtr_var
 
     killall -9 mysqld || true
     rm -rf $PWD/var_kv1_prod
+
+    if [[ "${HAVE_JUNIT}" == "1" ]]; then
+        JUNIT_VAULT_V2_PROD_TC_ARGS=" --junit-output=${RESULTS_DIR}/junit_keyring_vault_prod_v2.xml --junit-package=${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_prod_v2"
+    else
+        JUNIT_VAULT_V2_PROD_TC_ARGS=" --xml-report=${RESULTS_DIR}/junit_keyring_vault_prod_v2.xml"
+    fi
 
     MTR_VAULT_ADDRESS=${VAULT_V2_PROD_ADDRESS} \
     MTR_VAULT_ADMIN_TOKEN=${VAULT_V2_PROD_ROOT_TOKEN} \
@@ -549,8 +596,7 @@ if [[ ${KEYRING_VAULT_MTR} == 'yes' ]]; then
         ${MTR_ARGS_KV} \
         ${MTR_ARGS_KV_SUITE} \
         ${ANALYZER_MTR_ARGS} \
-        --junit-output=${RESULTS_DIR}/junit_keyring_vault_prod_v2.xml \
-        --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.WORKER_${WORKER_NO}.keyring_vault_prod_v2" || true
+        ${JUNIT_VAULT_V2_PROD_TC_ARGS} || true
 
     ln -s $PWD/var $PWD/var_kv2_prod
     rsync -a -L --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' $PWD/var_kv2_prod ${RESULTS_DIR}/mtr_var

--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -345,7 +345,7 @@ fi
 
 #
 # CI FS tests
-if [[ "${CI_FS_MTR}" = 'yes' ]]; then
+if [[ "${CI_FS_MTR}" == 'yes' ]]; then
     echo "Running CI FS tests"
     start=`date +%s`
 
@@ -361,14 +361,14 @@ if [[ "${CI_FS_MTR}" = 'yes' ]]; then
     # Collect all CI_FS tests
     CI_TESTS=$(grep --exclude="*.inc" --exclude="*.log" -rl . -e include/have_case_insensitive_file_system.inc | awk -F '/' '{print $(NF-2)"."$NF}' | sed 's/\.test//g' | sed 's/^\./main/g')
     # Requested in PS-7602
-    if [[ ${CMAKE_BUILD_TYPE} = 'Debug' ]]; then
+    if [[ "${SERVER_VERSION}" != 5.7.* && ${CMAKE_BUILD_TYPE} == Debug ]]; then
         CI_TESTS+=" information_schema.i_s_schema_definition_debug"
     fi
 
     # Filter out disabled tests
     # Skip lines starting with #
     # Grab until whitespace or :
-    DISABLED_TESTS=$(grep -P -o collections/disabled.def -e'^\s*[^#][^:\s]*')
+    DISABLED_TESTS=$(grep -P -o '^\s*[^#][^:\s]*' collections/disabled.def || true)
 
     set +x
     for CURRENT_TEST in $DISABLED_TESTS; do
@@ -404,7 +404,7 @@ fi
 
 #
 # PS PROTOCOL tests
-if [[ "${WITH_PS_PROTOCOL}" = 'yes' ]]; then
+if [[ "${SERVER_VERSION}" != 5.7.* && "${WITH_PS_PROTOCOL}" == 'yes' ]]; then
     echo "Running PS PROTOCOL tests"
     start=`date +%s`
 
@@ -420,7 +420,7 @@ if [[ "${WITH_PS_PROTOCOL}" = 'yes' ]]; then
     # Filter out disabled tests
     # Skip lines starting with #
     # Grab until whitespace or :
-    DISABLED_TESTS=$(grep -P -o collections/disabled.def -e'^\s*[^#][^:\s]*')
+    DISABLED_TESTS=$(grep -P -o '^\s*[^#][^:\s]*' collections/disabled.def || true)
 
     set +x
     for CURRENT_TEST in $DISABLED_TESTS; do


### PR DESCRIPTION
1. Remove validation of a server version (not needed when using `suite-groups.sh`)
2. Improve "execute()" to support MTR test names and suites
3. update pipeline for 57eol amzn private repo (port changes from @vorsel from 5.7)
4. Add support for 5.7 in ` build-binary` and `test-binary-parallel-mtr`
5. Add automatic detection of support for `--junit_package` using `grep -q "opt_junit_package" ./mysql-test-run.pl` and `HAVE_JUNIT`
6. Swtich to `--xml-report` if `--junit_package` is not supported