### PR TITLE
Add support for MySQL EOL dev repo in PS 5.7 pipeline job

### DIFF
--- a/jenkins/pipeline.groovy
+++ b/jenkins/pipeline.groovy
@@ -34,7 +34,7 @@ pipeline {
                         MY_BRANCH_BASE_MAJOR=5
                         MY_BRANCH_BASE_MINOR=7
                         GIT_REPO_LINK=${GIT_REPO}
-                        if [[ "${GIT_REPO}" =~ post-eol|private ]]; then
+                        if [[ "${GIT_REPO}" =~ post-eol|private|eol-dev ]]; then
                             GIT_REPO_LINK=$(echo ${GIT_REPO} | sed -e "s|github|x-access-token:${JNKPercona_token}@github|g")
                         fi
                         RAW_VERSION_LINK=$(echo ${GIT_REPO_LINK%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")

--- a/local/checkout
+++ b/local/checkout
@@ -15,7 +15,7 @@ set -o xtrace
 ROOT_DIR=$(cd $(dirname $0)/..; pwd -P)/sources
 
 if [ ! -d "${ROOT_DIR}" ]; then
-    if [[ "${GIT_REPO}" =~ post-eol|private ]]; then
+    if [[ "${GIT_REPO}" =~ post-eol|private|eol-dev ]]; then
         GIT_REPO=$(echo ${GIT_REPO} | sed -e "s|github|${JNKPercona_token}@github|")
     fi
     git clone "${GIT_REPO:-https://github.com/percona/percona-server}" "${ROOT_DIR}"


### PR DESCRIPTION
'mysql-eol-dev', a new private repository is created for the developers to create PRs and discuss fixes which is internal.

Allow PS 5.7 pipeline job to use the credentials to access the private repo similar to the original mysql-5.7-post-eol repo.

Note:-
The new repo has added support to JUNIT options.