### PR TITLE
PS-10166: Run docker with `mode=1777` in `run-test-parallel-mtr`

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -75,7 +75,7 @@ if [[ "${KEYRING_VAULT_MTR}" == 'yes' ]]; then
 fi
 
 docker run --rm --shm-size=32G \
-    --tmpfs /dev/shm:rw,exec,size=32G \
+    --tmpfs /dev/shm:rw,exec,size=32G,mode=1777 \
     --security-opt seccomp=unconfined \
     --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
     --mount type=bind,source=${SOURCES_DIR},destination=/tmp/sources \

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -270,7 +270,7 @@
     name: param-parallel-mtr-8.0
     ps_version: 8.0
     ps_version_no_dot: '8_0'
-    branch_name: release-8.0.43-34
+    branch_name: release-8.0.44-35
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -279,11 +279,14 @@
       - percona-server-{ps_version}-pipeline-parallel-mtr
 
 
+# ----------------------- VALGRIND --------------------------------
+
+
 - project:
-    name: pipeline-parallel-mtr-VALGRIND
-    ps_version: VALGRIND
-    branch_name: release-9.4.0-1
-    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --suite-timeout=600000 --retry-failure=0
+    name: pipeline-parallel-mtr-8.0-VALGRIND
+    ps_version: 8.0-VALGRIND
+    branch_name: 'release-8.0.44-35'
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
@@ -291,6 +294,94 @@
       - debian:bookworm
     sanitizer_opts_list:
       - -DWITH_VALGRIND=ON
+    jobs:
+      - percona-server-{ps_version}-pipeline-parallel-mtr
+
+- project:
+    name: pipeline-parallel-mtr-8.4-VALGRIND
+    ps_version: 8.4-VALGRIND
+    branch_name: 'release-8.4.7-7'
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --retry-failure=0
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: '8.0'
+    docker_os_list:
+      - ubuntu:noble
+      - debian:bookworm
+    sanitizer_opts_list:
+      - -DWITH_VALGRIND=ON
+    jobs:
+      - percona-server-{ps_version}-pipeline-parallel-mtr
+
+- project:
+    name: pipeline-parallel-mtr-9.7-VALGRIND
+    ps_version: 9.7-VALGRIND
+    branch_name: 'release-9.5.0-1'
+    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --retry-failure=0
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: '8.0'
+    docker_os_list:
+      - ubuntu:noble
+      - debian:bookworm
+    sanitizer_opts_list:
+      - -DWITH_VALGRIND=ON
+    jobs:
+      - percona-server-{ps_version}-pipeline-parallel-mtr
+
+
+# ----------------------- ASAN --------------------------------
+
+
+- project:
+    name: pipeline-parallel-mtr-8.0-ASAN
+    ps_version: 8.0-ASAN
+    branch_name: 'release-8.0.44-35'
+    mtr_opts: --unit-tests-report --big-test --retry-failure=0
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: '8.0'
+    docker_os_list:
+      - ubuntu:noble
+      - debian:bookworm
+    sanitizer_opts_list:
+      - -DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON
+      - -DWITH_ASAN=ON
+      - -DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON -DWITH_UBSAN=ON
+      - -DWITH_ASAN=ON -DWITH_UBSAN=ON
+      - -DWITH_UBSAN=ON
+      - -DWITH_MSAN=ON
+    jobs:
+      - percona-server-{ps_version}-pipeline-parallel-mtr
+
+- project:
+    name: pipeline-parallel-mtr-8.4-ASAN
+    ps_version: 8.4-ASAN
+    branch_name: 'release-8.4.7-7'
+    mtr_opts: --unit-tests-report --big-test --retry-failure=0
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: '8.0'
+    docker_os_list:
+      - ubuntu:noble
+      - debian:bookworm
+    sanitizer_opts_list:
+      - -DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON
+      - -DWITH_ASAN=ON
+      - -DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON -DWITH_UBSAN=ON
+      - -DWITH_ASAN=ON -DWITH_UBSAN=ON
+      - -DWITH_UBSAN=ON
+      - -DWITH_MSAN=ON
+    jobs:
+      - percona-server-{ps_version}-pipeline-parallel-mtr
+
+- project:
+    name: pipeline-parallel-mtr-9.7-ASAN
+    ps_version: 9.7-ASAN
+    branch_name: 'release-9.5.0-1'
+    mtr_opts: --unit-tests-report --big-test --retry-failure=0
+    scripts_repo: https://github.com/Percona-Lab/ps-build
+    scripts_branch: '8.0'
+    docker_os_list:
+      - ubuntu:noble
+      - debian:bookworm
+    sanitizer_opts_list:
       - -DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON
       - -DWITH_ASAN=ON
       - -DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON -DWITH_UBSAN=ON


### PR DESCRIPTION
1. Run docker with `mode=1777` in `run-test-parallel-mtr`
2. Add valgrind and ASan jobs for 8.0, 8.4, 9.x using Hetzner Cloud
