### PR TITLE
PS-10183: Install `gcc-toolset-14` for `centos:8` image

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -142,13 +142,6 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST+=" redhat-lsb-core"
     fi
 
-    if [[ ${RHVER} -eq 9 ]]; then
-        # Next packages are required by 9.4.0
-        PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-binutils"
-        PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-annobin-annocheck gcc-toolset-14-annobin-plugin-gcc"
-        PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-libatomic-devel"
-    fi
-
     if [[ ${RHVER} -eq 8 ]] || [[ ${RHVER} -eq 9 ]]; then
         # Next packages are required by 8.0.33
         PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ gcc-toolset-12-binutils"
@@ -159,6 +152,12 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET13+=" gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-binutils"
         PKGLIST_DEVTOOLSET13+=" gcc-toolset-13-annobin-annocheck gcc-toolset-13-annobin-plugin-gcc"
         PKGLIST_DEVTOOLSET13+=" gcc-toolset-13-libatomic-devel"
+
+        # Next packages are required for oraclelinux:9 starting from 9.4.0
+        # and for centos:8 starting from 9.5.0.
+        PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-binutils"
+        PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-annobin-annocheck gcc-toolset-14-annobin-plugin-gcc"
+        PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-libatomic-devel"
     fi
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -225,7 +224,7 @@ if [ -f /usr/bin/yum ]; then
     elif [[ ${RHVER} -eq 8 ]]; then
         yum -y install centos-release-stream
         switch_to_vault_repo
-        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13}; do
+        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13} ${PKGLIST_DEVTOOLSET14}; do
             echo "waiting"
             sleep 1
         done


### PR DESCRIPTION
Upstream has switched to `gcc-toolset-14` for RHEL-8 compatible distros in mysql-9.5.0.