### PR TITLE
PS-10183: Set USER env variable before running MTR to fix router.dest…

### DIFF
--- a/docker/run-test-parallel-mtr
+++ b/docker/run-test-parallel-mtr
@@ -116,6 +116,7 @@ docker run --rm --shm-size=32G \
     export WITH_ROCKSDB='${WITH_ROCKSDB}'
     export KEEP_BUILD='${KEEP_BUILD}'
     export EXECUTE_SUITES_ONE_BY_ONE='${EXECUTE_SUITES_ONE_BY_ONE}'
+    export USER='mysql'
 
     sudo chown mysql:mysql /tmp/work
     sudo chown -R mysql:mysql /tmp/work/results || :


### PR DESCRIPTION
…ination_socket failures in Jenkins.

This test expects USER environment variable to contain name of system user under which tests are executed. And normally, it is the case, as it is set accordingly by 'login' process. However, this variable is not set in Docker environment by default.

Fix test failures in Jenkins caused by this by explicitly setting USER environment variable before running MTR.