### PR TITLE
PS-10398 [8.0]: Always wipe WORK_DIR to avoid stale work/extract on reruns

### DIFF
--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -100,6 +100,16 @@ void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
             sudo git log --oneline -10
             sudo git reset --hard
 
+            wipe_work_dir() {
+                # "git clean" doesn't remove "sources/" because of ".gitignore"
+                sudo git clean -xdf || :
+                sudo rm -rf sources
+
+                # Ensure WORK_DIR is really clean (helps with re-runs / retries).
+                # "git clean" may leave parts of work/extract behind (e.g. "Directory not empty")
+                sudo rm -rf ${WORK_DIR}
+            }
+
             # "sources" + "work/build" required for running unit tests are valid only for "Test 1" (WORKER #1) but not for retry/re-runs
             if [ "$WORKER_ID" = "1" ] && [ "$UNIT_TESTS" != "false" ]; then
                 if [ -d sources ]; then
@@ -107,20 +117,21 @@ void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
                     if ! sudo git -C sources status >/dev/null 2>&1; then
                         echo "Warning: Git repo in ./sources is broken, removing it. It should happen only for re-runs."
                         sudo GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git -C sources -c safe.directory="$WORKSPACE/sources" log --oneline -10 || :
-                        sudo rm -rf sources
+                        wipe_work_dir
                     else
                         sudo git -C sources log --oneline -10
                         sudo git -C sources reset --hard
                         sudo git -C sources clean -xdf -e . || :
                         sudo git -C sources submodule update --init || :
+                        sudo rm -rf ${WORK_DIR}/extract ${WORK_DIR}/results ${WORK_DIR}/walltimes || :
+                        sudo rm -f  ${WORK_DIR}/binary.tar.gz ${WORK_DIR}/mtr-test_*.log || :
                     fi
                 else
                     echo "Warning: Missing 'sources' for MTR worker ${WORKER_ID}. It should happen only for re-runs."
+                    wipe_work_dir
                 fi
             else
-                # "git clean" doesn't remove "sources/" because of ".gitignore"
-                sudo git clean -xdf || :
-                sudo rm -rf sources
+                wipe_work_dir
             fi
 
             # import apt_get_retry(), yum_retry() from utils.inc.sh
@@ -140,11 +151,14 @@ void prepareWorkspace(Integer WORKER_ID, boolean UNIT_TESTS) {
 
 void cleanWorkspace(Integer WORKER_ID) {
     echo "[INFO] Worker ${WORKER_ID}: cleaning up workspace."
-    sh '''
+    sh """
         # "git clean" doesn't remove "sources/" because of ".gitignore"
         sudo git clean -xdf || :
         sudo rm -rf sources
-    '''
+
+        # Ensure WORK_DIR is really clean (helps with re-runs / retries).
+        sudo rm -rf ${WORK_DIR}
+    """
 }
 
 void doTests(String WORKER_ID, String SUITES, String STANDALONE_TESTS = '', boolean UNIT_TESTS = false, boolean CIFS_TESTS = false, boolean KV_TESTS = false, boolean PS_PROTOCOL_TESTS = false) {
@@ -287,14 +301,17 @@ void doTestWorkerJob(Integer WORKER_ID, String SUITES, String STANDALONE_TESTS =
 void checkoutSources() {
     echo 'Checkout PS sources'
     withCredentials([string(credentialsId: 'JNKPercona', variable: 'JNKPercona_token')]) {
-        sh '''
+        sh """
             # sudo is needed for better node recovery after compilation failure
             # if building failed on compilation stage directory will have files owned by docker user
             sudo git reset --hard
             sudo git clean -xdf || :
             sudo rm -rf sources
+
+            # Ensure WORK_DIR is really clean (helps with re-runs / retries).
+            sudo rm -rf ${WORK_DIR}
             ./local/checkout
-        '''
+        """
     }
 }
 

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -318,16 +318,19 @@ void checkoutSources() {
 void build(String SCRIPT) {
     timeout(time: 180, unit: 'MINUTES')  {
         withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: AWS_CREDENTIALS_ID, secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-            sh """
+            sh """#!/bin/bash
+                set -euo pipefail
                 aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
-                sg docker -c "
-                    if [ \$(docker ps -q | wc -l) -ne 0 ]; then
+
+                sg docker -c '
+                    if docker ps -q | grep -q .; then
                         docker ps -q | xargs docker stop --time 1 || :
                     fi
-                    eval USE_CCACHE=${params.USE_CCACHE} CCACHE_MAXSIZE=${env.CCACHE_MAXSIZE} KEEP_BUILD=yes ${SCRIPT} ${DOCKER_OS} ${WORKSPACE}/${WORK_DIR}
-                " 2>&1 | tee build.log
 
-                echo Archive build log: \$(date -u "+%s")
+                    eval USE_CCACHE=${params.USE_CCACHE} CCACHE_MAXSIZE=${env.CCACHE_MAXSIZE} KEEP_BUILD=yes ${SCRIPT} ${DOCKER_OS} ${WORKSPACE}/${WORK_DIR}
+                ' 2>&1 | tee build.log
+
+                echo "Archive build log: \$(date -u '+%s')"
                 sed -i -e '
                     s^/tmp/ps/^sources/^;
                     s^/tmp/results/^sources/^;


### PR DESCRIPTION
1. `git clean -xdf` sometimes leaves work/extract behind (e.g. “Directory not empty”), which can cause later MTR workers to see stale/partial extraction state and fail with missing files (like `mysql-test-run.pl`).
Add an explicit `sudo rm -rf ${WORK_DIR}` cleanup in `prepareWorkspace()` so reruns start from a clean `work/` directory.
2. Add `set -euo pipefail` to detect failures in `./docker/run-build`.