### PR TITLE
PS-10408: Fix tar failure after EXTRACT_DIR removal by restoring cwd

### DIFF
--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -640,6 +640,7 @@ if [[ "${KEEP_BUILD}" != "yes" ]]; then
     rm -rf ${EXTRACT_DIR}
 fi
 
+cd ${WORKDIR}
 tar -C ${RESULTS_DIR} --owner=0 --group=0 -czf "${RESULTS_DIR}/ps80-test-mtr_logs-${WORKER_NO}.tar.gz" mtr_var
 
 ls -l ${WORKDIR}


### PR DESCRIPTION
When `KEEP_BUILD!=yes`, `rm -rf ${EXTRACT_DIR}` deletes the shell's current working directory. The subsequent tar command then fails with `Cannot getcwd: No such file or directory`. Add `cd ${WORKDIR}` before tar to move into a directory that is guaranteed to still exist.