### PR TITLE
PS-10569: Add Debian 13 (Trixie) and OracleLinux 10 Docker build images

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -283,7 +283,11 @@ if [ -f /usr/bin/yum ]; then
     if [[ ${RHVER} -eq 7 ]] && [[ "x${DIST}" != "x.amzn2" ]]; then
         source /opt/rh/devtoolset-7/enable
     fi
-    pip3 install mysqlclient
+    if [[ ${RHVER} -ge 10 ]]; then
+        pip3 install --break-system-packages mysqlclient
+    else
+        pip3 install mysqlclient
+    fi
 
 #   this is workaround for https://bugs.mysql.com/bug.php?id=95222 as soon as the issue is fixed we need to remove it 
     if [ -f '/anaconda-post.log' ]; then

--- a/docker/install-deps
+++ b/docker/install-deps
@@ -55,6 +55,11 @@ if [ -f /usr/bin/yum ]; then
         echo "waiting"
         sleep 1
       done
+  elif [[ ${RHVER} -eq 10 ]]; then
+      until yum -y install oracle-epel-release-el10; do
+        echo "waiting"
+        sleep 1
+      done
   else
       until yum -y install epel-release; do
         echo "waiting"
@@ -98,6 +103,17 @@ if [ -f /usr/bin/yum ]; then
       PKGLIST+=" libedit-devel"
   fi
 
+  if [[ ${RHVER} -eq 10 ]]; then
+      PKGLIST+=" dnf-utils"
+      until yum -y install ${PKGLIST} ; do
+        echo "waiting"
+        sleep 1
+      done
+
+      dnf config-manager --enable ol10_codeready_builder
+      PKGLIST+=" libedit-devel"
+  fi
+
   if [[ ${RHVER} -lt 8 ]] && [[ "$(rpm --eval %{_arch})" == "x86_64" ]] && [[ "x${DIST}" != "x.amzn2" ]]; then
     until yum -y install centos-release-scl; do
       echo "waiting"
@@ -122,14 +138,20 @@ if [ -f /usr/bin/yum ]; then
     perl-Time-HiRes openldap-devel perl-Env perl-Data-Dumper libicu-devel perl-Sys-MemInfo \
     cpio perl-JSON perl-Digest perl-Digest-MD5 perl-XML-Parser perl-Expect perl-LWP-Protocol-https \
     numactl-devel git which make rpm-build ccache sudo libasan lz4-devel \
-    libzstd-devel tzdata zstd mysql-devel perl-DBI perl-DBD-mysql jq perl-XML-Simple libcurl-devel perl-Test-Simple \
+    libzstd-devel tzdata zstd perl-DBI perl-DBD-mysql jq perl-XML-Simple libcurl-devel perl-Test-Simple \
     cyrus-sasl-devel cyrus-sasl-scram krb5-devel libudev-devel python3-pip python3-devel libevent-devel \
     "
   if [[ "x${DIST}" != "x.amzn2" ]]; then
       PKGLIST+=" openssl-devel openssl "
   fi
 
-    if [[ ${RHVER} -eq 9 ]]; then
+  if [[ ${RHVER} -eq 10 ]]; then
+      PKGLIST+=" mariadb-connector-c-devel"
+  else
+      PKGLIST+=" mysql-devel"
+  fi
+
+    if [[ ${RHVER} -eq 9 ]] || [[ ${RHVER} -eq 10 ]]; then
         PKGLIST+=" gflags-devel util-linux libtirpc-devel rpcgen"
     fi
 
@@ -147,6 +169,13 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-binutils"
         PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-annobin-annocheck gcc-toolset-14-annobin-plugin-gcc"
         PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-libatomic-devel"
+    fi
+
+    if [[ ${RHVER} -eq 10 ]]; then
+        # OL10 only has gcc-toolset-15
+        PKGLIST_DEVTOOLSET15+=" gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-binutils"
+        PKGLIST_DEVTOOLSET15+=" gcc-toolset-15-gcc-plugin-annobin"
+        PKGLIST_DEVTOOLSET15+=" gcc-toolset-15-libatomic-devel"
     fi
 
     if [[ ${RHVER} -eq 8 ]] || [[ ${RHVER} -eq 9 ]]; then
@@ -235,9 +264,14 @@ if [ -f /usr/bin/yum ]; then
             echo "waiting"
             sleep 1
         done
+    elif [[ ${RHVER} -eq 10 ]]; then
+        until yum -y install ${PKGLIST_DEVTOOLSET15}; do
+            echo "waiting"
+            sleep 1
+        done
     fi
 
-    if [[ ${RHVER} -eq 8 ]] || [[ ${RHVER} -eq 9 ]]; then
+    if [[ ${RHVER} -eq 8 ]] || [[ ${RHVER} -eq 9 ]] || [[ ${RHVER} -eq 10 ]]; then
         ln -fs /usr/bin/python3 /usr/bin/python
     fi
 
@@ -282,17 +316,23 @@ if [ -f /usr/bin/apt-get ]; then
         libmecab-dev libncurses5-dev libreadline-dev libpam-dev zlib1g-dev libcurl4-openssl-dev \
         libnuma-dev libjemalloc-dev libc6-dbg valgrind libjson-perl libexpect-perl libevent-dev pkg-config \
         libmecab2 mecab mecab-ipadic git autoconf libsasl2-dev libsasl2-modules devscripts \
-        debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev liblz4-tool libedit-dev libssl-dev \
+        debconf debhelper fakeroot po-debconf psmisc ccache libtool sudo liblz4-dev libedit-dev libssl-dev \
         tzdata golang libunwind-dev zstd python3-mysqldb libdbi-perl libdbd-mysql-perl \
         cpio jq openssl libxml-simple-perl libxml-parser-perl \
         libsasl2-dev libsasl2-modules-gssapi-mit libkrb5-dev libudev-dev libzstd-dev libsys-meminfo-perl \
         libatomic1 \
     "
 
-    if [[ ${DIST} == "bookworm" ]] || [[ ${DIST} == "noble" ]]; then
+    if [[ ${DIST} == "bookworm" ]] || [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]]; then
         PKGLIST+=" gsasl-common"
     else
         PKGLIST+=" libgsasl7"
+    fi
+
+    if [[ ${DIST} == "trixie" ]]; then
+        PKGLIST+=" lz4"
+    else
+        PKGLIST+=" liblz4-tool"
     fi
 
     # PS 8.2 requires gcc-10 on focal
@@ -300,11 +340,11 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" gcc-10 g++-10"
     fi
 
-    if [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]] || [[ ${DIST} == 'bookworm' ]] || [[ ${DIST} == "noble" ]]; then
+    if [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]] || [[ ${DIST} == 'bookworm' ]] || [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]]; then
         PKGLIST+=" libgflags-dev util-linux"
     fi
 
-    if [[ ${DIST} == "noble" ]]; then
+    if [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]]; then
         PKGLIST+=" libtirpc-dev"
     fi
 

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -25,7 +25,7 @@
     - matrix-combinations:
         name: COMBINATIONS
         description: "Select matrix combinations"
-        filter: CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64"
+        filter: CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:trixie" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:trixie" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:10" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:10" && ARCH=="x86_64"
     - string:
         name: GIT_REPO
         default: "https://github.com/percona/percona-server"
@@ -276,11 +276,13 @@
     docker_os_list:
       - centos:8
       - oraclelinux:9
+      - oraclelinux:10
       - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye
       - debian:bookworm
+      - debian:trixie
     jobs:
       - percona-server-{ps_version}-param-parallel-mtr
 
@@ -294,11 +296,13 @@
     docker_os_list:
       - centos:8
       - oraclelinux:9
+      - oraclelinux:10
       - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye
       - debian:bookworm
+      - debian:trixie
     jobs:
       - percona-server-{ps_version}-param-parallel-mtr
 
@@ -312,8 +316,10 @@
     docker_os_list:
       - centos:8
       - oraclelinux:9
+      - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bookworm
+      - debian:trixie
     jobs:
       - percona-server-{ps_version}-param-parallel-mtr

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -230,11 +230,13 @@
     docker_os_list:
       - centos:8
       - oraclelinux:9
+      - oraclelinux:10
       - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye
       - debian:bookworm
+      - debian:trixie
     sanitizer_opts_list:
       -
     jobs:
@@ -250,11 +252,13 @@
     docker_os_list:
       - centos:8
       - oraclelinux:9
+      - oraclelinux:10
       - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye
       - debian:bookworm
+      - debian:trixie
     sanitizer_opts_list:
       -
     jobs:
@@ -270,9 +274,11 @@
     docker_os_list:
       - centos:8
       - oraclelinux:9
+      - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bookworm
+      - debian:trixie
     sanitizer_opts_list:
       -
     jobs:

--- a/jenkins/prepare-ps-build-docker.groovy
+++ b/jenkins/prepare-ps-build-docker.groovy
@@ -39,11 +39,13 @@ pipeline {
                 parallel(
                     "centos:8":        { build('centos:8') },
                     "oraclelinux:9":   { build('oraclelinux:9') },
+                    "oraclelinux:10":  { build('oraclelinux:10') },
                     "ubuntu:focal":    { build('ubuntu:focal') },
                     "ubuntu:jammy":    { build('ubuntu:jammy') },
                     "ubuntu:noble":    { build('ubuntu:noble') },
                     "debian:bullseye": { build('debian:bullseye') },
                     "debian:bookworm": { build('debian:bookworm') },
+                    "debian:trixie":   { build('debian:trixie') },
                 )
             }
         }


### PR DESCRIPTION
## Summary

- Add Debian 13 (Trixie) and OracleLinux 10 support to `docker/install-deps`
- Add both OS variants to the parallel Docker image build matrix in `prepare-ps-build-docker.groovy`
- Update `pipeline-parallel-mtr.yml` and `param-parallel-mtr.yml` with new OS entries for 8.0, 8.x, 9.x

### OracleLinux 10
- oracle-epel-release-el10, ol10_codeready_builder repo
- mariadb-connector-c-devel (replaces mysql-devel)
- gcc-toolset-15 only (12/13/14 not available on OL10)
- gcc-toolset-15-gcc-plugin-annobin (single package vs split on OL9)
- pip3 --break-system-packages for PEP 668

### Debian Trixie
- lz4 replaces liblz4-tool (removed in Trixie)
- gsasl-common, libgflags-dev, libtirpc-dev conditionals

## Related
- Jira: [PS-10569](https://perconadev.atlassian.net/browse/PS-10569) / [PKG-1285](https://perconadev.atlassian.net/browse/PKG-1285)
- Companion PR: https://github.com/Percona-Lab/jenkins-pipelines/pull/3819 (PXC build images)
