### PR TITLE
PS-10571: replace centos:8 with oraclelinux:8 in Docker build images

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -38,7 +38,7 @@ if [ -f /usr/bin/yum ]; then
   DIST="$(rpm --eval %dist)"
   rpm --eval %_arch > /etc/yum/vars/basearch
 
-  if [ "x${RHVER}" = "x8" -o "x${RHVER}" = "x7" ]; then
+  if [ "x${RHVER}" = "x7" ]; then
       switch_to_vault_repo
   fi
 
@@ -57,6 +57,11 @@ if [ -f /usr/bin/yum ]; then
       done
   elif [[ ${RHVER} -eq 10 ]]; then
       until yum -y install oracle-epel-release-el10; do
+        echo "waiting"
+        sleep 1
+      done
+  elif [[ ${RHVER} -eq 8 ]]; then
+      until yum -y install oracle-epel-release-el8; do
         echo "waiting"
         sleep 1
       done
@@ -88,7 +93,7 @@ if [ -f /usr/bin/yum ]; then
         sleep 1
       done
 
-      dnf config-manager --set-enabled powertools
+      dnf config-manager --enable ol8_codeready_builder
       PKGLIST+=" libedit-devel"
   fi
 
@@ -164,8 +169,8 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST+=" redhat-lsb-core"
     fi
 
-    if [[ ${RHVER} -eq 9 ]]; then
-        # Next packages are required by 9.4.0
+    if [[ ${RHVER} -eq 8 ]] || [[ ${RHVER} -eq 9 ]]; then
+        # Next packages are required by 9.4.0 / 9.6.0
         PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-binutils"
         PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-annobin-annocheck gcc-toolset-14-annobin-plugin-gcc"
         PKGLIST_DEVTOOLSET14+=" gcc-toolset-14-libatomic-devel"
@@ -252,13 +257,10 @@ if [ -f /usr/bin/yum ]; then
         done
         switch_to_vault_repo
     elif [[ ${RHVER} -eq 8 ]]; then
-        yum -y install centos-release-stream
-        switch_to_vault_repo
-        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13}; do
+        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13} ${PKGLIST_DEVTOOLSET14}; do
             echo "waiting"
             sleep 1
         done
-        yum -y remove centos-release-stream
     elif [[ ${RHVER} -eq 9 ]]; then
         until yum -y install ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13} ${PKGLIST_DEVTOOLSET14}; do
             echo "waiting"

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -274,7 +274,7 @@
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - oraclelinux:10
       - ubuntu:focal
@@ -294,7 +294,7 @@
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - oraclelinux:10
       - ubuntu:focal
@@ -314,7 +314,7 @@
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - oraclelinux:10
       - ubuntu:jammy

--- a/jenkins/pipeline-57-parallel-mtr.yml
+++ b/jenkins/pipeline-57-parallel-mtr.yml
@@ -218,7 +218,7 @@
     docker_os_list:
       - ubuntu:noble
       - centos:7
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - ubuntu:bionic
       - ubuntu:focal

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -228,7 +228,7 @@
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - oraclelinux:10
       - ubuntu:focal
@@ -250,7 +250,7 @@
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - oraclelinux:10
       - ubuntu:focal
@@ -272,7 +272,7 @@
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
-      - centos:8
+      - oraclelinux:8
       - oraclelinux:9
       - oraclelinux:10
       - ubuntu:jammy

--- a/jenkins/prepare-ps-build-docker.groovy
+++ b/jenkins/prepare-ps-build-docker.groovy
@@ -37,7 +37,7 @@ pipeline {
         stage('Build') {
             steps {
                 parallel(
-                    "centos:8":        { build('centos:8') },
+                    "oraclelinux:8":   { build('oraclelinux:8') },
                     "oraclelinux:9":   { build('oraclelinux:9') },
                     "oraclelinux:10":  { build('oraclelinux:10') },
                     "ubuntu:focal":    { build('ubuntu:focal') },

--- a/local/build-binary
+++ b/local/build-binary
@@ -172,7 +172,7 @@ fi
 # ------------------------------------------------------------------------------
 if [[ ${WITH_JS_LANG} == 'ON' ]]; then
     V8_VERSION=$(grep 'SET(EXPECTED_V8_VERSION' ${SOURCEDIR}/cmake/v8.cmake | sed -re 's/.*"([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
-    if [[ "${DOCKER_OS}" == "centos-8" ]] || [[ "${DOCKER_OS}" == "debian-bullseye" ]] || [[ "${DOCKER_OS}" == "ubuntu-focal" ]]; then
+    if [[ "${DOCKER_OS}" == "oraclelinux-8" ]] || [[ "${DOCKER_OS}" == "debian-bullseye" ]] || [[ "${DOCKER_OS}" == "ubuntu-focal" ]]; then
       # Platforms with older glibc need V8 built against older glibc as well.
       V8_ARCHIVE_NAME=v8_${V8_VERSION}-glibc2.31
     else


### PR DESCRIPTION
## Summary
- Replace CentOS 8 (EOL Dec 2021) with OracleLinux 8 (EOL 2029) for Docker build images
- OracleLinux 8 provides native gcc-toolset-14 (required by PS 9.6.0)
- Remove CentOS 8 vault mirror workarounds and centos-release-stream hack

## Changes
- `docker/install-deps`: vault mirror restricted to RHEL7 only; `oracle-epel-release-el8` replaces `epel-release`; `ol8_codeready_builder` replaces `powertools`; gcc-toolset-14 added for RHEL8; `centos-release-stream` hack removed
- `jenkins/prepare-ps-build-docker.groovy`: `centos:8` -> `oraclelinux:8` in parallel stages
- `jenkins/*-parallel-mtr.yml`: `centos:8` -> `oraclelinux:8` in docker_os_list
- `local/build-binary`: `centos-8` -> `oraclelinux-8` in V8 glibc check