### PR TITLE
PS-10408: Remove unsupported `ubuntu:focal` from pipelines

### DIFF
--- a/docker/run-build
+++ b/docker/run-build
@@ -74,11 +74,16 @@ docker run --rm \
     export DOCKER_OS='${SOURCE_IMAGE}'
     export KEEP_BUILD='${KEEP_BUILD}'
 
-    sudo chown mysql:mysql /tmp/work /tmp/sources /tmp/sources/mysql-test/collections /tmp/sources/storage/rocksdb/rocksdb/util /tmp/sources/rocksdb/util /tmp/ccache || :
+    MYROCKS_DIR=/tmp/sources/storage/rocksdb/rocksdb/util
+    if [ ! -d "\$MYROCKS_DIR" ]; then
+        MYROCKS_DIR=/tmp/sources/rocksdb/util
+        if [ ! -d "\$MYROCKS_DIR" ]; then MYROCKS_DIR=; fi
+    fi
+    sudo chown mysql:mysql /tmp/work /tmp/sources /tmp/sources/mysql-test/collections \$MYROCKS_DIR /tmp/ccache || :
     cp -r /tmp/source_downloads /tmp/work/source_downloads
 
     bash -x /tmp/scripts/build-binary /tmp/work /tmp/sources
 
     rm -rf /tmp/work/source_downloads
-    sudo chown $(id -u):$(id -g) /tmp/work /tmp/sources /tmp/sources/mysql-test/collections /tmp/sources/storage/rocksdb/rocksdb/util /tmp/sources/rocksdb/util /tmp/ccache || :
+    sudo chown $(id -u):$(id -g) /tmp/work /tmp/sources /tmp/sources/mysql-test/collections \$MYROCKS_DIR /tmp/ccache || :
 "

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -277,7 +277,6 @@
       - centos:8
       - oraclelinux:9
       - oraclelinux:10
-      - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye
@@ -297,7 +296,6 @@
       - centos:8
       - oraclelinux:9
       - oraclelinux:10
-      - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye

--- a/jenkins/pipeline-57-parallel-mtr.yml
+++ b/jenkins/pipeline-57-parallel-mtr.yml
@@ -221,7 +221,6 @@
       - centos:8
       - oraclelinux:9
       - ubuntu:bionic
-      - ubuntu:focal
       - ubuntu:jammy
       - debian:buster
       - debian:bullseye

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -1003,22 +1003,22 @@ pipeline {
     post {
         success {
             script {
-                notifySlack(currentBuild.currentResult, '#36a64f', '[{jobName}]: is {status}! :rocket: Started by {userId} ({email} / <@{slackUserId}>).')
+                notifySlack(currentBuild.currentResult, '#36a64f', "[{jobName}]: is {status}! :rocket:\nStarted by {userId} ({email} / <@{slackUserId}>).\n${DOCKER_OS} ${ARCH} ${CMAKE_BUILD_TYPE}")
             }
         }
         failure {
             script {
-                notifySlack(currentBuild.currentResult, '#36a64f', '[{jobName}]: has {status}! :face_with_peeking_eye: Started by {userId} ({email} / <@{slackUserId}>).')
+                notifySlack(currentBuild.currentResult, '#36a64f', "[{jobName}]: has {status}! :face_with_peeking_eye:\nStarted by {userId} ({email} / <@{slackUserId}>).\n${DOCKER_OS} ${ARCH} ${CMAKE_BUILD_TYPE}")
             }
         }
         aborted {
             script {
-                notifySlack(currentBuild.currentResult, '#36a64f', '[{jobName}]: has {status}! :axe: Started by {userId} ({email} / <@{slackUserId}>).')
+                notifySlack(currentBuild.currentResult, '#36a64f', "[{jobName}]: has {status}! :axe:\nStarted by {userId} ({email} / <@{slackUserId}>).\n${DOCKER_OS} ${ARCH} ${CMAKE_BUILD_TYPE}")
             }
         }
         unstable {
             script {
-                notifySlack(currentBuild.currentResult, '#36a64f', '[{jobName}]: is {status}! :warning: Started by {userId} ({email} / <@{slackUserId}>).')
+                notifySlack(currentBuild.currentResult, '#36a64f', "[{jobName}]: is {status}! :warning:\nStarted by {userId} ({email} / <@{slackUserId}>).\n${DOCKER_OS} ${ARCH} ${CMAKE_BUILD_TYPE}")
             }
         }
         always {

--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -1023,7 +1023,7 @@ pipeline {
         }
         always {
             triggerAbortedTestWorkersRerun()
-            sh 'echo Finish: \$(date -u "+%s")'
+            echo "Finish: ${(long)(System.currentTimeMillis() / 1000)}"
         }
     }
 }

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -231,7 +231,6 @@
       - centos:8
       - oraclelinux:9
       - oraclelinux:10
-      - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye
@@ -253,7 +252,6 @@
       - centos:8
       - oraclelinux:9
       - oraclelinux:10
-      - ubuntu:focal
       - ubuntu:jammy
       - ubuntu:noble
       - debian:bullseye

--- a/jenkins/prepare-ps-build-docker.groovy
+++ b/jenkins/prepare-ps-build-docker.groovy
@@ -40,7 +40,6 @@ pipeline {
                     "centos:8":        { build('centos:8') },
                     "oraclelinux:9":   { build('oraclelinux:9') },
                     "oraclelinux:10":  { build('oraclelinux:10') },
-                    "ubuntu:focal":    { build('ubuntu:focal') },
                     "ubuntu:jammy":    { build('ubuntu:jammy') },
                     "ubuntu:noble":    { build('ubuntu:noble') },
                     "debian:bullseye": { build('debian:bullseye') },


### PR DESCRIPTION
- Remove unsupported `ubuntu:focal` from pipelines
- Add DOCKER_OS, ARCH, and CMAKE_BUILD_TYPE to Slack notifications
- Fix chown failure when MyRocks directory does not exist
- Use Groovy echo for finish timestamp in post block
