### PR TITLE
PS-10985: Add Ubuntu 26.04 (Resolute) docker image

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -329,13 +329,13 @@ if [ -f /usr/bin/apt-get ]; then
         libatomic1 \
     "
 
-    if [[ ${DIST} == "bookworm" ]] || [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]]; then
+    if [[ ${DIST} == "bookworm" ]] || [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]] || [[ ${DIST} == "resolute" ]]; then
         PKGLIST+=" gsasl-common"
     else
         PKGLIST+=" libgsasl7"
     fi
 
-    if [[ ${DIST} == "trixie" ]]; then
+    if [[ ${DIST} == "trixie" ]] || [[ ${DIST} == "resolute" ]]; then
         PKGLIST+=" lz4"
     else
         PKGLIST+=" liblz4-tool"
@@ -346,11 +346,11 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" gcc-10 g++-10"
     fi
 
-    if [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]] || [[ ${DIST} == 'bookworm' ]] || [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]]; then
+    if [[ ${DIST} == 'jammy' ]] || [[ ${DIST} == 'bullseye' ]] || [[ ${DIST} == 'bookworm' ]] || [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]] || [[ ${DIST} == "resolute" ]]; then
         PKGLIST+=" libgflags-dev util-linux"
     fi
 
-    if [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]]; then
+    if [[ ${DIST} == "noble" ]] || [[ ${DIST} == "trixie" ]] || [[ ${DIST} == "resolute" ]]; then
         PKGLIST+=" libtirpc-dev"
     fi
 

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -25,7 +25,7 @@
     - matrix-combinations:
         name: COMBINATIONS
         description: "Select matrix combinations"
-        filter: CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:trixie" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:trixie" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:10" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:10" && ARCH=="x86_64"
+        filter: CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:noble" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="ubuntu:resolute" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="ubuntu:resolute" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:bookworm" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="debian:trixie" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="debian:trixie" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:9" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="Debug" && DOCKER_OS=="oraclelinux:10" && ARCH=="x86_64" || CMAKE_BUILD_TYPE=="RelWithDebInfo" && DOCKER_OS=="oraclelinux:10" && ARCH=="x86_64"
     - string:
         name: GIT_REPO
         default: "https://github.com/percona/percona-server"
@@ -279,6 +279,7 @@
       - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
+      - ubuntu:resolute
       - debian:bullseye
       - debian:bookworm
       - debian:trixie
@@ -298,6 +299,7 @@
       - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
+      - ubuntu:resolute
       - debian:bullseye
       - debian:bookworm
       - debian:trixie
@@ -317,6 +319,7 @@
       - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
+      - ubuntu:resolute
       - debian:bookworm
       - debian:trixie
     jobs:

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -240,6 +240,7 @@
       - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
+      - ubuntu:resolute
       - debian:bullseye
       - debian:bookworm
       - debian:trixie
@@ -261,6 +262,7 @@
       - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
+      - ubuntu:resolute
       - debian:bullseye
       - debian:bookworm
       - debian:trixie
@@ -282,6 +284,7 @@
       - oraclelinux:10
       - ubuntu:jammy
       - ubuntu:noble
+      - ubuntu:resolute
       - debian:bookworm
       - debian:trixie
     sanitizer_opts_list:

--- a/jenkins/prepare-ps-build-docker.groovy
+++ b/jenkins/prepare-ps-build-docker.groovy
@@ -42,6 +42,7 @@ pipeline {
                     "oraclelinux:10":  { build('oraclelinux:10') },
                     "ubuntu:jammy":    { build('ubuntu:jammy') },
                     "ubuntu:noble":    { build('ubuntu:noble') },
+                    "ubuntu:resolute": { build('ubuntu:resolute') },
                     "debian:bullseye": { build('debian:bullseye') },
                     "debian:bookworm": { build('debian:bookworm') },
                     "debian:trixie":   { build('debian:trixie') },


### PR DESCRIPTION
## Changes

**`docker/install-deps`**

Add `resolute` to the modern-Ubuntu codename branches:

- `gsasl-common` (joins bookworm / noble / trixie)
- `lz4` (joins trixie, replacing `liblz4-tool`)
- `libgflags-dev` + `util-linux` (joins jammy / bullseye / bookworm / noble / trixie)
- `libtirpc-dev` (joins noble / trixie)

**`jenkins/prepare-ps-build-docker.groovy`**

Add `"ubuntu:resolute": { build('ubuntu:resolute') }` to the parallel matrix.

**`jenkins/pipeline-parallel-mtr.yml`**

Append `ubuntu:resolute` to `docker_os_list` for the three mainline projects (8.0, 8.x, 9.x). Sanitizer and valgrind variants stay on noble + bookworm.

**`jenkins/param-parallel-mtr.yml`**

Append `ubuntu:resolute` to `docker_os_list` for 8.0, 8.x, 9.x, and extend the `COMBINATIONS` filter so resolute is a default-checked matrix combination.

---

[PS-10985](https://perconadev.atlassian.net/browse/PS-10985)