### PR TITLE
PS-11165: Install libquadmath-devel for OracleLinux 10 build image

### DIFF
--- a/docker/install-deps
+++ b/docker/install-deps
@@ -152,6 +152,9 @@ if [ -f /usr/bin/yum ]; then
 
   if [[ ${RHVER} -eq 10 ]]; then
       PKGLIST+=" mariadb-connector-c-devel"
+      if [[ "$(rpm --eval %{_arch})" == "x86_64" ]]; then
+          PKGLIST+=" libquadmath-devel"
+      fi
   else
       PKGLIST+=" mysql-devel"
   fi


### PR DESCRIPTION
**Bug**
- PS `release-8.4.9-9` fails to compile on the OracleLinux 10 build image. MySQL 8.4.9's updated Boost requires the `<quadmath.h>` header, and `libquadmath-devel` is not installed.

**Fix**
- Add `libquadmath-devel` to the OL10 package list in `docker/install-deps`, guarded to `x86_64`. The package is absent on OL10 aarch64, where Boost does not need the header, so the guard keeps the aarch64 image build green.

**Tickets**
- This fix: [PS-11165](https://perconadev.atlassian.net/browse/PS-11165). Origin: [PS-10569](https://perconadev.atlassian.net/browse/PS-10569).
- PXC sibling: [PXC-5234](https://perconadev.atlassian.net/browse/PXC-5234).
- Companion: [jenkins-pipelines PR 4122](https://github.com/Percona-Lab/jenkins-pipelines/pull/4122).
