### PR TITLE
PS-11179: Default ps57 PS MTR to CLOUD=auto

### DIFF
--- a/jenkins/pipeline-57-parallel-mtr.yml
+++ b/jenkins/pipeline-57-parallel-mtr.yml
@@ -131,11 +131,11 @@
     - choice:
         name: CLOUD
         choices:
+        - "auto"
         - "Hetzner"
         - "AWS"
         - "epyc9654"
-        - "auto"
-        description: "Host provider for Jenkins workers. `auto` routes arm64 builds to AWS Graviton when Hetzner ARM (CAX) capacity is unavailable; x86 always stays on Hetzner."
+        description: "Host provider for Jenkins workers. `auto` routes arm64 builds to AWS Graviton when Hetzner ARM (CAX) capacity is unavailable; x86 always stays on Hetzner. Explicit `Hetzner`/`AWS`/`epyc9654` skip the fallback."
     - choice:
         name: FULL_MTR
         choices:


### PR DESCRIPTION
**Feature**
- Flips default `CLOUD` choice for the 3 ps57 PS MTR jobs from `Hetzner` to `auto`, rolling `resolveArmWorker` routing to ps57 leaves once predecessor [PR 518](https://github.com/Percona-Lab/ps-build/pull/518) merges + canary green.

**Why**
- Substrate live: resolver + flag in [PR 4125](https://github.com/Percona-Lab/jenkins-pipelines/pull/4125) merged, Graviton Fleet on ps57 via [cd PR 18](https://github.com/percona/percona-cd-platform/pull/18), `EC2FleetCloud` codified in [PR 4126](https://github.com/Percona-Lab/jenkins-pipelines/pull/4126); smoke validated end-to-end on `m8g.2xlarge`.
- ps57 = 3 jobs = small blast surface; ps80 (9 jobs) follows post-Friday [PS-11206](https://perconadev.atlassian.net/browse/PS-11206) cutover.

**Tickets**
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179) (this PR) / Predecessor [PR 518](https://github.com/Percona-Lab/ps-build/pull/518) / Sequel PR C (ps80 default flip).