### PR TITLE
PS-11179: Default ps57 PS MTR to CLOUD=auto

### DIFF
--- a/jenkins/pipeline-57-parallel-mtr.yml
+++ b/jenkins/pipeline-57-parallel-mtr.yml
@@ -131,11 +131,11 @@
     - choice:
         name: CLOUD
         choices:
+        - "auto"
         - "Hetzner"
         - "AWS"
         - "epyc9654"
-        - "auto"
-        description: "Host provider for Jenkins workers. `auto` routes arm64 builds to AWS Graviton when Hetzner ARM (CAX) capacity is unavailable; x86 always stays on Hetzner."
+        description: "Host provider for Jenkins workers. `auto` routes arm64 builds to AWS Graviton when Hetzner ARM (CAX) capacity is unavailable; x86 always stays on Hetzner. Explicit `Hetzner`/`AWS`/`epyc9654` skip the fallback."
     - choice:
         name: FULL_MTR
         choices:


### PR DESCRIPTION
**Feature**
- Flips the default `CLOUD` choice for the 3 ps57 PS MTR jobs from `Hetzner` to `auto`, so `resolveArmWorker` routes them automatically.

**Why**
- Hetzner ARM (CAX) capacity has been unavailable since 2026-04-02 with no vendor ETA, so ps57 arm64 MTR builds stall in the Hetzner queue during release windows.
- With `Hetzner` as the default, those builds never reach the AWS Graviton fallback that is already live on ps57 (fleet + health probe), so the outage keeps blocking ARM validation.
- The `auto` mode sends arm64 to AWS Graviton only when the controller flag reports Hetzner ARM down, and leaves x86_64 on Hetzner; ps80 already defaults to `auto` ([PR 522](https://github.com/Percona-Lab/ps-build/pull/522), merged), so this brings ps57 to parity.

**Tickets**
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179) (this PR); pipeline wiring [PR 518](https://github.com/Percona-Lab/ps-build/pull/518) (merged).
- Companion: [PR 522](https://github.com/Percona-Lab/ps-build/pull/522) (merged), the ps80 default flip on `param-parallel-mtr` + `pipeline-parallel-mtr`.