### PR TITLE
Ps 10414: Remove "innodb_use_native_aio=0" valgrind workaround

### DIFF
--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -270,7 +270,7 @@
     name: param-parallel-mtr-8.0
     ps_version: 8.0
     ps_version_no_dot: '8_0'
-    branch_name: release-8.0.45-36
+    branch_name: release-8.0.46-37
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
@@ -287,10 +287,10 @@
       - percona-server-{ps_version}-param-parallel-mtr
 
 - project:
-    name: param-parallel-mtr-8.x
-    ps_version: 8.x
-    ps_version_no_dot: '8_x'
-    branch_name: release-8.4.8-8
+    name: param-parallel-mtr-8.4
+    ps_version: 8.4
+    ps_version_no_dot: '8_4'
+    branch_name: release-8.4.9-9
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:
@@ -307,10 +307,10 @@
       - percona-server-{ps_version}-param-parallel-mtr
 
 - project:
-    name: param-parallel-mtr-9.x
-    ps_version: 9.x
-    ps_version_no_dot: '9_x'
-    branch_name: release-9.6.0-1
+    name: param-parallel-mtr-9.7
+    ps_version: 9.7
+    ps_version_no_dot: '9_7'
+    branch_name: release-9.7.0-1
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: 8.0
     docker_os_list:

--- a/jenkins/param-parallel-mtr.yml
+++ b/jenkins/param-parallel-mtr.yml
@@ -141,6 +141,7 @@
         - "Hetzner"
         - "AWS"
         - "epyc9654"
+        - "auto"
         description: "Host provider for Jenkins workers"
     - choice:
         name: FULL_MTR

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -251,8 +251,8 @@
       - percona-server-{ps_version}-pipeline-parallel-mtr
 
 - project:
-    name: pipeline-parallel-mtr-8.x
-    ps_version: 8.x
+    name: pipeline-parallel-mtr-8.4
+    ps_version: 8.4
     branch_name: '8.4'
     mtr_opts: --unit-tests-report --mem --big-test
     scripts_repo: https://github.com/Percona-Lab/ps-build
@@ -273,8 +273,8 @@
       - percona-server-{ps_version}-pipeline-parallel-mtr
 
 - project:
-    name: pipeline-parallel-mtr-9.x
-    ps_version: 9.x
+    name: pipeline-parallel-mtr-9.7
+    ps_version: 9.7
     branch_name: 'trunk'
     mtr_opts: --unit-tests-report --mem --big-test
     scripts_repo: https://github.com/Percona-Lab/ps-build
@@ -300,11 +300,12 @@
 - project:
     name: pipeline-parallel-mtr-8.0-VALGRIND
     ps_version: 8.0-VALGRIND
-    branch_name: 'release-8.0.45-36'
-    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --retry-failure=0
+    branch_name: 'release-8.0.46-37'
+    mtr_opts: --unit-tests-report --big-test --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
+      - ubuntu:resolute
       - ubuntu:noble
       - debian:bookworm
     sanitizer_opts_list:
@@ -315,11 +316,12 @@
 - project:
     name: pipeline-parallel-mtr-8.4-VALGRIND
     ps_version: 8.4-VALGRIND
-    branch_name: 'release-8.4.8-8'
-    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --retry-failure=0
+    branch_name: 'release-8.4.9-9'
+    mtr_opts: --unit-tests-report --big-test --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
+      - ubuntu:resolute
       - ubuntu:noble
       - debian:bookworm
     sanitizer_opts_list:
@@ -330,11 +332,12 @@
 - project:
     name: pipeline-parallel-mtr-9.7-VALGRIND
     ps_version: 9.7-VALGRIND
-    branch_name: 'release-9.6.0-1'
-    mtr_opts: --unit-tests-report --big-test --mysqld=--innodb_use_native_aio=0 --retry-failure=0
+    branch_name: 'release-9.7.0-1'
+    mtr_opts: --unit-tests-report --big-test --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
+      - ubuntu:resolute
       - ubuntu:noble
       - debian:bookworm
     sanitizer_opts_list:
@@ -349,11 +352,12 @@
 - project:
     name: pipeline-parallel-mtr-8.0-ASAN
     ps_version: 8.0-ASAN
-    branch_name: 'release-8.0.45-36'
+    branch_name: 'release-8.0.46-37'
     mtr_opts: --unit-tests-report --big-test --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
+      - ubuntu:resolute
       - ubuntu:noble
       - debian:bookworm
     sanitizer_opts_list:
@@ -369,11 +373,12 @@
 - project:
     name: pipeline-parallel-mtr-8.4-ASAN
     ps_version: 8.4-ASAN
-    branch_name: 'release-8.4.8-8'
+    branch_name: 'release-8.4.9-9'
     mtr_opts: --unit-tests-report --big-test --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
+      - ubuntu:resolute
       - ubuntu:noble
       - debian:bookworm
     sanitizer_opts_list:
@@ -389,11 +394,12 @@
 - project:
     name: pipeline-parallel-mtr-9.7-ASAN
     ps_version: 9.7-ASAN
-    branch_name: 'release-9.6.0-1'
+    branch_name: 'release-9.7.0-1'
     mtr_opts: --unit-tests-report --big-test --retry-failure=0
     scripts_repo: https://github.com/Percona-Lab/ps-build
     scripts_branch: '8.0'
     docker_os_list:
+      - ubuntu:resolute
       - ubuntu:noble
       - debian:bookworm
     sanitizer_opts_list:


### PR DESCRIPTION
1. Add "auto" CLOUD choice to param-parallel-mtr

Allow selecting "auto" as the host provider so the job can use
resolveArmWorker's Hetzner to AWS Graviton fallback.

2. Remove "innodb_use_native_aio=0" valgrind workaround

Valgrind 3.25 added support for syscall 333 (io_pgetevents), which is
used by libaio for InnoDB native async I/O. Older valgrind versions
reported "WARNING: unhandled amd64-linux syscall: 333", which we worked
around by passing --mysqld=--innodb_use_native_aio=0 to MTR in the
VALGRIND pipelines.

Ubuntu 26.04 (Resolute) ships valgrind 3.25, so:
- drop the innodb_use_native_aio=0 workaround from the 8.0/8.4/9.7
  VALGRIND pipeline-parallel-mtr jobs
- add ubuntu:resolute to the VALGRIND and ASAN docker_os_list

Also bump tested release branches (8.0.46-37, 8.4.9-9, 9.7.0-1) and
rename the 8.x projects to 8.4 and 9.x projects to 9.7.
