### PR TITLE
PS-11214: Point valgrind --skip-test-list at the extracted mysql-test tree

### DIFF
--- a/local/test-binary-parallel-mtr
+++ b/local/test-binary-parallel-mtr
@@ -194,11 +194,6 @@ ANALYZER_MTR_ARGS=""
 #
 if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
   ANALYZER_MTR_ARGS+=" --valgrind --valgrind-clients --valgrind-option=--leak-check=full --valgrind-option=--show-leak-kinds=all"
-  # Skip tests known to time out / be too slow under valgrind, if the list is present.
-  # (mysql-test-run.pl errors out if --skip-test-list points to a missing file.)
-  if [[ -f "${BUILD_DIR}/mysql-test/collections/valgrind-skip.list" ]]; then
-    ANALYZER_MTR_ARGS+=" --skip-test-list=${BUILD_DIR}/mysql-test/collections/valgrind-skip.list"
-  fi
   # defaults from mtr-test-run.pl; it will by multiplied later ($opt_testcase_timeout*= 10, $opt_suite_timeout*= 6)
   TESTCASE_TIMEOUT=15
   SUITE_TIMEOUT=300
@@ -368,6 +363,13 @@ fi
 #
 # Running MTR test cases
 MTR_ARGS="${MTR_ARGS} --no-unit-tests"
+
+# Skip tests known to time out / be too slow under valgrind, if the list is
+# present in the extracted tree (mysql-test-run.pl errors if the file is missing).
+if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]] && \
+   [[ -f "${EXTRACT_DIR}/mysql-test/collections/valgrind-skip.list" ]]; then
+  MTR_ARGS="${MTR_ARGS} --skip-test-list=${EXTRACT_DIR}/mysql-test/collections/valgrind-skip.list"
+fi
 
 
 # >>>> main MTR execution loop starts here


### PR DESCRIPTION
The skip-test-list was added in the pre-extraction WITH_VALGRIND block and referenced ${BUILD_DIR}, but suites run from ${EXTRACT_DIR}/mysql-test after the binary tarball is unpacked. Move the (guarded) --skip-test-list next to where the suite MTR_ARGS is finalized and point it at ${EXTRACT_DIR}/mysql-test/collections/valgrind-skip.list, so the file exists when checked and the flag reaches the suite runs.