### PR TITLE
PS-11214: Trim valgrind pipelines to ubuntu:resolute and stop archiving result XMLs

### DIFF
--- a/jenkins/pipeline-parallel-mtr.groovy
+++ b/jenkins/pipeline-parallel-mtr.groovy
@@ -261,7 +261,7 @@ void doTestWorkerJobWithoutGuard(Integer WORKER_ID, String SUITES, String STANDA
             echo "[WARNING] Worker ${WORKER_ID} failed with error: ${err}"
             throw err // rethrow so outer catchError or pipeline failure handling still works
         } finally {
-            archiveArtifacts "${WORK_DIR}/*.log*,${WORK_DIR}/walltimes/*.txt,${WORK_DIR}/results/*.xml,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
+            archiveArtifacts "${WORK_DIR}/*.log*,${WORK_DIR}/walltimes/*.txt,${WORK_DIR}/results/ps80-test-mtr_logs-*.tar.gz"
 
             // This is questionable. Do we need result XMLs in S3 cache while Jenkins archives them as well?
             syncDirToS3("./${WORK_DIR}/results/", "${BUILD_TAG_BINARIES}", 'mtr_var/*')

--- a/jenkins/pipeline-parallel-mtr.yml
+++ b/jenkins/pipeline-parallel-mtr.yml
@@ -306,8 +306,6 @@
     scripts_branch: '8.0'
     docker_os_list:
       - ubuntu:resolute
-      - ubuntu:noble
-      - debian:bookworm
     sanitizer_opts_list:
       - -DWITH_VALGRIND=ON
     jobs:
@@ -322,8 +320,6 @@
     scripts_branch: '8.0'
     docker_os_list:
       - ubuntu:resolute
-      - ubuntu:noble
-      - debian:bookworm
     sanitizer_opts_list:
       - -DWITH_VALGRIND=ON
     jobs:
@@ -338,8 +334,6 @@
     scripts_branch: '8.0'
     docker_os_list:
       - ubuntu:resolute
-      - ubuntu:noble
-      - debian:bookworm
     sanitizer_opts_list:
       - -DWITH_VALGRIND=ON
     jobs:


### PR DESCRIPTION
On Jenkins, valgrind chokes on the syscall InnoDB native AIO uses:

```
--WARNING: unhandled amd64-linux syscall: 333
--You may be able to write your own handler.
--Read the file README_MISSING_SYSCALL_OR_IOCTL.
--Nevertheless we consider this a bug.
```

To run valgrind you therefore need one of:

- Ubuntu 26.04 Resolute, whose valgrind 3.25 handles syscall 333, or
- `--mysqld=--innodb_use_native_aio=0` in `MTR_ARGS` (removed when `ubuntu:resolute` became the default)

So restrict the valgrind `docker_os_list` to `ubuntu:resolute` (drop `ubuntu:noble` and `debian:bookworm`) and remove the `results/*.xml` glob from `archiveArtifacts`, since the result XMLs are already synced to S3.